### PR TITLE
v1.2.0

### DIFF
--- a/PosInformatique.Moq.Analyzers.sln
+++ b/PosInformatique.Moq.Analyzers.sln
@@ -41,6 +41,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Compilation", "Compilation"
 	ProjectSection(SolutionItems) = preProject
 		docs\Compilation\PosInfoMoq2000.md = docs\Compilation\PosInfoMoq2000.md
 		docs\Compilation\PosInfoMoq2001.md = docs\Compilation\PosInfoMoq2001.md
+		docs\Compilation\PosInfoMoq2002.md = docs\Compilation\PosInfoMoq2002.md
 	EndProjectSection
 EndProject
 Global

--- a/PosInformatique.Moq.Analyzers.sln
+++ b/PosInformatique.Moq.Analyzers.sln
@@ -40,6 +40,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Compilation", "Compilation", "{D9C84D36-7F9C-4EFB-BE6F-9F7A05FE957D}"
 	ProjectSection(SolutionItems) = preProject
 		docs\Compilation\PosInfoMoq2000.md = docs\Compilation\PosInfoMoq2000.md
+		docs\Compilation\PosInfoMoq2001.md = docs\Compilation\PosInfoMoq2001.md
 	EndProjectSection
 EndProject
 Global

--- a/README.md
+++ b/README.md
@@ -38,3 +38,6 @@ All the rules of this category should not be disabled (or changed their severity
 | Rule | Description |
 | - | - |
 | [PosInfoMoq2000: The `Returns()` or `ReturnsAsync()` methods must be call for Strict mocks](docs/Compilation/PosInfoMoq2000.md) | When a `Mock<T>` has been defined with the `Strict` behavior, the `Returns()` or `ReturnsAsync()` method must be called when setup a method to mock which returns a value. |
+| [PosInfoMoq2001: The `Setup()` method must be used only on overridable members](docs/Compilation/PosInfoMoq2001.md)) | The `Setup()` method must be applied only for overridable members. |
+| [PosInfoMoq2002: `Mock<T>` class can be used only to mock non-sealed class](docs/Compilation/PosInfoMoq2002.md) | The `Mock<T>` can mock only interfaces or non-`sealed` classes. |
+

--- a/build/azure-pipelines-release.yaml
+++ b/build/azure-pipelines-release.yaml
@@ -2,7 +2,7 @@ parameters:
 - name: VersionPrefix
   displayName: The version of the library
   type: string
-  default: 1.1.0
+  default: 1.2.0
 - name: VersionSuffix
   displayName: The version suffix of the library (rc.1). Use a space ' ' if no suffix.
   type: string

--- a/docs/Compilation/PosInfoMoq2000.md
+++ b/docs/Compilation/PosInfoMoq2000.md
@@ -1,11 +1,11 @@
 # PosInfoMoq2000: The `Returns()` or `ReturnsAsync()` methods must be call for Strict mocks
 
-| Property                            | Value                                                                                      |
-|-------------------------------------|--------------------------------------------------------------------------------------------|
-| **Rule ID**                         | PosInfoMoq2000                                                                                    |
-| **Title**                           | The `Returns()` or `ReturnsAsync()` methods must be call for Strict mocks                |
-| **Category**                        | Compilation																			       |
-| **Default severity**				  | Error																				       |
+| Property                            | Value                                                                       |
+|-------------------------------------|-----------------------------------------------------------------------------|
+| **Rule ID**                         | PosInfoMoq2000                                                              |
+| **Title**                           | The `Returns()` or `ReturnsAsync()` methods must be call for Strict mocks   |
+| **Category**                        | Compilation																	|
+| **Default severity**				  | Error																		|
 
 ## Cause
 

--- a/docs/Compilation/PosInfoMoq2001.md
+++ b/docs/Compilation/PosInfoMoq2001.md
@@ -1,0 +1,61 @@
+# PosInfoMoq2001: The `Setup()` method must be used only on overridable members
+
+| Property                            | Value                                                         |
+|-------------------------------------|---------------------------------------------------------------|
+| **Rule ID**                         | PosInfoMoq2001                                                |
+| **Title**                           | The `Setup()` method must be used only on overridable members |
+| **Category**                        | Compilation													  |
+| **Default severity**				  | Error														  |
+
+## Cause
+
+The `Setup()` method must be applied only for overridable members.
+An overridable member is a **methode** or **property** which is in:
+- An `interface`.
+- A non-`sealed` `class`. In this case, the member must be:
+    - Defines as `abstract`.
+	- Or defined as `virtual`
+
+## Rule description
+
+The `Setup()` method must be applied only for overridable members.
+
+For example, the following methods and properties can be mock and used in the `Setup()` method:
+- `IService.MethodCanBeMocked()`
+- `IService.PropertyCanBeMocked`
+- `Service.VirtualMethodCanBeMocked`
+- `Service.VirtualPropertyCanBeMocked`
+- `Service.AbstractMethodCanBeMocked`
+- `Service.AbstractPropertyCanBeMocked`
+
+```csharp
+public interface IService
+{
+	void MethodCanBeMocked();
+
+	string PropertyCanBeMocked { get; set; }
+}
+
+public abstract class Service
+{
+	public virtual void VirtualMethodCanBeMocked() { ... }
+
+	public virtual void VirtualPropertyCanBeMocked() { ... }
+
+	public abstract void AbstractMethodCanBeMocked();
+
+	public abstract void AbstractPropertyCanBeMocked();
+}
+```
+
+> **NOTE**: The extension methods can not be overriden. The C# syntax looks like a member method an interface or class, but the extension method are just simple
+static methods which can not be overriden.
+
+## How to fix violations
+
+To fix a violation of this rule, be sure to mock a member in the `Setup()` method which can be overriden.
+
+## When to suppress warnings
+
+Do not suppress an error from this rule. If bypassed, the execution of the unit test will be failed with a `MoqException`
+thrown with the *"Extensions methods may not be used in setup/verification expressions"* message.

--- a/docs/Compilation/PosInfoMoq2002.md
+++ b/docs/Compilation/PosInfoMoq2002.md
@@ -1,0 +1,42 @@
+# PosInfoMoq2002: `Mock<T>` class can be used only to mock non-sealed class
+
+| Property                            | Value                                                         |
+|-------------------------------------|---------------------------------------------------------------|
+| **Rule ID**                         | PosInfoMoq2002                                                |
+| **Title**                           | `Mock<T>` class can be used only to mock non-sealed class     |
+| **Category**                        | Compilation													  |
+| **Default severity**				  | Error														  |
+
+## Cause
+
+The `Mock<T>` can mock only interfaces or non-`sealed` classes.
+
+## Rule description
+
+The `Mock<T>` method must be use only on the interfaces or non-`sealed` classes.
+
+For example, the following code can not mock the `Service` class because it is `sealed`.
+
+```csharp
+[Fact]
+public void Test()
+{
+	var service = new Mock<Service>();		// The Service can not be mocked, because it is a sealed class.
+	service.Setup(s => s.GetData())
+		.Returns(10);
+}
+
+public class Service
+{
+	public virtual int GetData() { }
+}
+```
+
+## How to fix violations
+
+To fix a violation of this rule, be sure to mock interfaces or non-sealed classes.
+
+## When to suppress warnings
+
+Do not suppress an error from this rule. If bypassed, the execution of the unit test will be failed with a `MoqException`
+thrown with the *"Type to mock (xxx) must be an interface, a delegate, or a non-selead, non-static class"* message.

--- a/src/Moq.Analyzers/AnalyzerReleases.Shipped.md
+++ b/src/Moq.Analyzers/AnalyzerReleases.Shipped.md
@@ -1,4 +1,12 @@
-﻿## Release 1.1.0
+﻿## Release 1.2.0
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|--------------------
+PosInfoMoq2001  | Compilation | Error  | The `Setup()` method can be used only on overridable members
+
+## Release 1.1.0
 
 ### New Rules
 

--- a/src/Moq.Analyzers/AnalyzerReleases.Shipped.md
+++ b/src/Moq.Analyzers/AnalyzerReleases.Shipped.md
@@ -4,7 +4,8 @@
 
 Rule ID | Category | Severity | Notes
 --------|----------|----------|--------------------
-PosInfoMoq2001  | Compilation | Error  | The `Setup()` method can be used only on overridable members
+PosInfoMoq2001  | Compilation | Error  | The `Setup()` method can be used only on overridable members.
+PosInfoMoq2002  | Compilation | Error  | `Mock<T>` class can be used only to mock non-sealed class.
 
 ## Release 1.1.0
 
@@ -12,7 +13,7 @@ PosInfoMoq2001  | Compilation | Error  | The `Setup()` method can be used only o
 
 Rule ID | Category | Severity | Notes
 --------|----------|----------|--------------------
-PosInfoMoq2000  | Compilation | Error  | The `Returns()` or `ReturnsAsync()` method must be called for Strict mocks
+PosInfoMoq2000  | Compilation | Error  | The `Returns()` or `ReturnsAsync()` method must be called for Strict mocks.
 
 ## Release 1.0.0
 
@@ -20,5 +21,5 @@ PosInfoMoq2000  | Compilation | Error  | The `Returns()` or `ReturnsAsync()` met
 
 Rule ID | Category | Severity | Notes
 --------|----------|----------|--------------------
-PosInfoMoq1000  | Design   | Warning  | `Verify()` and `VerifyAll()` methods should be called when instantiate a Mock<T> instances
-PosInfoMoq1001  | Design   | Warning  | The `Mock<T>` instance behavior should be defined to Strict mode
+PosInfoMoq1000  | Design   | Warning  | `Verify()` and `VerifyAll()` methods should be called when instantiate a Mock<T> instances.
+PosInfoMoq1001  | Design   | Warning  | The `Mock<T>` instance behavior should be defined to Strict mode.

--- a/src/Moq.Analyzers/Analyzers/MockInstanceShouldBeStrictBehaviorAnalyzer.cs
+++ b/src/Moq.Analyzers/Analyzers/MockInstanceShouldBeStrictBehaviorAnalyzer.cs
@@ -47,13 +47,15 @@ namespace PosInformatique.Moq.Analyzers
                 return;
             }
 
+            var moqExpressionAnalyzer = new MoqExpressionAnalyzer(context.SemanticModel);
+
             // Check there is "new Mock<I>()" statement.
-            if (!MockExpressionHelper.IsMockCreation(moqSymbols, context.SemanticModel, objectCreation))
+            if (!moqExpressionAnalyzer.IsMockCreation(moqSymbols, objectCreation))
             {
                 return;
             }
 
-            if (!MockExpressionHelper.IsStrictBehavior(moqSymbols, context.SemanticModel, objectCreation))
+            if (!moqExpressionAnalyzer.IsStrictBehavior(moqSymbols, objectCreation))
             {
                 var diagnostic = Diagnostic.Create(Rule, objectCreation.GetLocation());
                 context.ReportDiagnostic(diagnostic);

--- a/src/Moq.Analyzers/Analyzers/SetupMethodMustReturnValueWithStrictBehaviorAnalyzer.cs
+++ b/src/Moq.Analyzers/Analyzers/SetupMethodMustReturnValueWithStrictBehaviorAnalyzer.cs
@@ -45,14 +45,16 @@ namespace PosInformatique.Moq.Analyzers
                 return;
             }
 
+            var moqExpressionAnalyzer = new MoqExpressionAnalyzer(context.SemanticModel);
+
             // Check is Setup() method.
-            if (!MockExpressionHelper.IsMockSetupMethod(moqSymbols, context.SemanticModel, invocationExpression, out var localVariableExpression))
+            if (!moqExpressionAnalyzer.IsMockSetupMethod(moqSymbols, invocationExpression, out var localVariableExpression))
             {
                 return;
             }
 
             // Check the mocked method return type (if "void", we skip the analysis, because no Returns() is required).
-            var mockedMethodReturnTypeSymbol = MockExpressionHelper.GetSetupMethodReturnSymbol(moqSymbols, context.SemanticModel, invocationExpression);
+            var mockedMethodReturnTypeSymbol = moqExpressionAnalyzer.GetSetupMethodReturnSymbol(moqSymbols, invocationExpression);
             if (mockedMethodReturnTypeSymbol is null)
             {
                 return;
@@ -64,7 +66,7 @@ namespace PosInformatique.Moq.Analyzers
             }
 
             // Check the behavior of the mock instance is Strict.
-            if (!MockExpressionHelper.IsStrictBehavior(moqSymbols, context.SemanticModel, localVariableExpression!))
+            if (!moqExpressionAnalyzer.IsStrictBehavior(moqSymbols, localVariableExpression!))
             {
                 return;
             }

--- a/src/Moq.Analyzers/Analyzers/SetupMustBeUsedOnlyForOverridableMembersAnalyzer.cs
+++ b/src/Moq.Analyzers/Analyzers/SetupMustBeUsedOnlyForOverridableMembersAnalyzer.cs
@@ -1,0 +1,73 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="SetupMustBeUsedOnlyForOverridableMembersAnalyzer.cs" company="P.O.S Informatique">
+//     Copyright (c) P.O.S Informatique. All rights reserved.
+// </copyright>
+//-----------------------------------------------------------------------
+
+namespace PosInformatique.Moq.Analyzers
+{
+    using System.Collections.Immutable;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
+    using Microsoft.CodeAnalysis.Diagnostics;
+
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class SetupMustBeUsedOnlyForOverridableMembersAnalyzer : DiagnosticAnalyzer
+    {
+        private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+            "PosInfoMoq2001",
+            "The Setup() method must be used only on overridable members",
+            "The Setup() method must be used only on overridable members",
+            "Compilation",
+            DiagnosticSeverity.Error,
+            isEnabledByDefault: true,
+            description: "The Setup() method must be used only on overridable members.");
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.EnableConcurrentExecution();
+
+            context.RegisterSyntaxNodeAction(Analyze, SyntaxKind.InvocationExpression);
+        }
+
+        private static void Analyze(SyntaxNodeAnalysisContext context)
+        {
+            var invocationExpression = (InvocationExpressionSyntax)context.Node;
+
+            var moqSymbols = MoqSymbols.FromCompilation(context.Compilation);
+
+            if (moqSymbols is null)
+            {
+                return;
+            }
+
+            // Check is Setup() method.
+            if (!MockExpressionHelper.IsMockSetupMethod(moqSymbols, context.SemanticModel, invocationExpression, out var _))
+            {
+                return;
+            }
+
+            // Extracts the method in the lambda expression of the Setup() method
+            var memberSetup = MockExpressionHelper.ExtractSetupMember(context.SemanticModel, invocationExpression, out var memberExpression);
+
+            if (memberSetup is null)
+            {
+                return;
+            }
+
+            // Check if the member is overridable.
+            if (moqSymbols.IsOverridable(memberSetup))
+            {
+                return;
+            }
+
+            // No returns method has been specified with Strict mode. Report the diagnostic issue.
+            var diagnostic = Diagnostic.Create(Rule, memberExpression!.GetLocation());
+            context.ReportDiagnostic(diagnostic);
+        }
+    }
+}

--- a/src/Moq.Analyzers/Analyzers/SetupMustBeUsedOnlyForOverridableMembersAnalyzer.cs
+++ b/src/Moq.Analyzers/Analyzers/SetupMustBeUsedOnlyForOverridableMembersAnalyzer.cs
@@ -45,14 +45,16 @@ namespace PosInformatique.Moq.Analyzers
                 return;
             }
 
+            var moqExpressionAnalyzer = new MoqExpressionAnalyzer(context.SemanticModel);
+
             // Check is Setup() method.
-            if (!MockExpressionHelper.IsMockSetupMethod(moqSymbols, context.SemanticModel, invocationExpression, out var _))
+            if (!moqExpressionAnalyzer.IsMockSetupMethod(moqSymbols, invocationExpression, out var _))
             {
                 return;
             }
 
             // Extracts the method in the lambda expression of the Setup() method
-            var memberSetup = MockExpressionHelper.ExtractSetupMember(context.SemanticModel, invocationExpression, out var memberExpression);
+            var memberSetup = moqExpressionAnalyzer.ExtractSetupMember(invocationExpression, out var memberExpression);
 
             if (memberSetup is null)
             {

--- a/src/Moq.Analyzers/Analyzers/VerifyAllShouldBeCalledAnalyzer.cs
+++ b/src/Moq.Analyzers/Analyzers/VerifyAllShouldBeCalledAnalyzer.cs
@@ -45,7 +45,9 @@ namespace PosInformatique.Moq.Analyzers
                 return;
             }
 
-            if (!MockExpressionHelper.IsMockCreation(moqSymbols, context.SemanticModel, objectCreation))
+            var moqExpressionAnalyzer = new MoqExpressionAnalyzer(context.SemanticModel);
+
+            if (!moqExpressionAnalyzer.IsMockCreation(moqSymbols, objectCreation))
             {
                 return;
             }

--- a/src/Moq.Analyzers/Moq.Analyzers.csproj
+++ b/src/Moq.Analyzers/Moq.Analyzers.csproj
@@ -17,8 +17,8 @@
     <PackageProjectUrl>https://github.com/PosInformatique/PosInformatique.Moq.Analyzers</PackageProjectUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>
-	  1.1.0
-	  - Add new rules:
+      1.1.0
+      - Add new rules:
         - PosInfoMoq2000: The `Returns()` or `ReturnsAsync()` methods must be call for Strict mocks.
 
       1.0.0

--- a/src/Moq.Analyzers/MoqSymbols.cs
+++ b/src/Moq.Analyzers/MoqSymbols.cs
@@ -188,6 +188,11 @@ namespace PosInformatique.Moq.Analyzers
                 return true;
             }
 
+            if (method.IsOverride)
+            {
+                return true;
+            }
+
             return false;
         }
     }

--- a/src/Moq.Analyzers/MoqSymbols.cs
+++ b/src/Moq.Analyzers/MoqSymbols.cs
@@ -170,5 +170,25 @@ namespace PosInformatique.Moq.Analyzers
 
             return true;
         }
+
+        public bool IsOverridable(ISymbol method)
+        {
+            if (method.ContainingType.TypeKind == TypeKind.Interface)
+            {
+                return true;
+            }
+
+            if (method.IsAbstract)
+            {
+                return true;
+            }
+
+            if (method.IsVirtual)
+            {
+                return true;
+            }
+
+            return false;
+        }
     }
 }

--- a/tests/Moq.Analyzers.Tests/Analyzers/NoSealedClassAnalyzerTest.cs
+++ b/tests/Moq.Analyzers.Tests/Analyzers/NoSealedClassAnalyzerTest.cs
@@ -1,0 +1,119 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="NoSealedClassAnalyzerTest.cs" company="P.O.S Informatique">
+//     Copyright (c) P.O.S Informatique. All rights reserved.
+// </copyright>
+//-----------------------------------------------------------------------
+
+namespace PosInformatique.Moq.Analyzers.Tests
+{
+    using System.Threading.Tasks;
+    using Xunit;
+    using Verify = Microsoft.CodeAnalysis.CSharp.Testing.CSharpAnalyzerVerifier<
+        NoSealedClassAnalyzer,
+        Microsoft.CodeAnalysis.Testing.DefaultVerifier>;
+
+    public class NoSealedClassAnalyzerTest
+    {
+        [Fact]
+        public async Task NoSealedClass_NoDiagnosticReported()
+        {
+            var source = @"
+                namespace ConsoleApplication1
+                {
+                    using Moq;
+                    using System;
+
+                    public class TestClass
+                    {
+                        public void TestMethod()
+                        {
+                            var mock1 = new Mock<I>();
+
+                            var mock2 = new Mock<StandardClass>();
+
+                            var mock3 = new Mock<AbstractClass>();
+
+                            var obj = new object();     // Ignored by the analysis.
+                        }
+                    }
+
+                    public interface I
+                    {
+                    }
+
+                    public class StandardClass
+                    {
+                    }
+
+                    public abstract class AbstractClass
+                    {
+                    }
+                }
+                " + MoqLibrary.Code;
+
+            await Verify.VerifyAnalyzerAsync(source);
+        }
+
+        [Fact]
+        public async Task SealedClass_NoDiagnosticReported()
+        {
+            var source = @"
+                namespace ConsoleApplication1
+                {
+                    using Moq;
+                    using System;
+
+                    public class TestClass
+                    {
+                        public void TestMethod()
+                        {
+                            var mock1 = new Mock<[|SealedClass|]>();
+                            var mock2 = new Mock<[|string|]>();
+                            var mock3 = new Mock<[|int|]>();
+                        }
+                    }
+
+                    public sealed class SealedClass
+                    {
+                    }
+                }
+                " + MoqLibrary.Code;
+
+            await Verify.VerifyAnalyzerAsync(source);
+        }
+
+        [Fact]
+        public async Task NoMoqLibrary()
+        {
+            var source = @"
+                namespace ConsoleApplication1
+                {
+                    using OtherNamespace;
+
+                    public class TestClass
+                    {
+                        public void TestMethod()
+                        {
+                            var mock1 = new Mock<I>(MockBehavior.Strict);
+                        }
+                    }
+
+                    public interface I
+                    {
+                    }
+                }
+
+                namespace OtherNamespace
+                {
+                    public class Mock<T>
+                    {
+                        public Mock(MockBehavior _) { }
+                    }
+
+                    public enum MockBehavior { Strict, Loose }
+                }";
+
+            await Verify.VerifyAnalyzerAsync(source);
+        }
+    }
+}

--- a/tests/Moq.Analyzers.Tests/Analyzers/SetupMustBeUsedOnlyForOverridableMembersAnalyzerTest.cs
+++ b/tests/Moq.Analyzers.Tests/Analyzers/SetupMustBeUsedOnlyForOverridableMembersAnalyzerTest.cs
@@ -1,0 +1,170 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="SetupMustBeUsedOnlyForOverridableMembersAnalyzerTest.cs" company="P.O.S Informatique">
+//     Copyright (c) P.O.S Informatique. All rights reserved.
+// </copyright>
+//-----------------------------------------------------------------------
+
+namespace PosInformatique.Moq.Analyzers.Tests
+{
+    using System.Threading.Tasks;
+    using Xunit;
+    using Verify = Microsoft.CodeAnalysis.CSharp.Testing.CSharpAnalyzerVerifier<
+        SetupMustBeUsedOnlyForOverridableMembersAnalyzer,
+        Microsoft.CodeAnalysis.Testing.DefaultVerifier>;
+
+    public class SetupMustBeUsedOnlyForOverridableMembersAnalyzerTest
+    {
+        [Fact]
+        public async Task Overridable_NoDiagnosticReported()
+        {
+            var source = @"
+                namespace ConsoleApplication1
+                {
+                    using Moq;
+                    using System;
+
+                    public class TestClass
+                    {
+                        public void TestMethod()
+                        {
+                            var mock1 = new Mock<I>();
+                            mock1.Setup(i => i.TestMethod());
+                            mock1.Setup(i => i.TestProperty);
+
+                            var mock2 = new Mock<StandardClass>();
+                            mock2.Setup(i => i.VirtualMethod());
+                            mock2.Setup(i => i.VirtualProperty);
+
+                            var mock3 = new Mock<AbstractClass>();
+                            mock3.Setup(i => i.VirtualMethod());
+                            mock3.Setup(i => i.VirtualProperty);
+                            mock3.Setup(i => i.AbstractMethod());
+                            mock3.Setup(i => i.AbstractProperty);
+                        }
+                    }
+
+                    public interface I
+                    {
+                        int TestMethod();
+
+                        string TestProperty { get; }
+                    }
+
+                    public class StandardClass
+                    {
+                        public virtual void VirtualMethod() { }
+
+                        public virtual string VirtualProperty => null;
+                    }
+
+                    public abstract class AbstractClass
+                    {
+                        public virtual void VirtualMethod() { }
+
+                        public virtual string VirtualProperty => null;
+
+                        public abstract void AbstractMethod();
+
+                        public abstract string AbstractProperty { get; }
+                    }
+                }
+                " + MoqLibrary.Code;
+
+            await Verify.VerifyAnalyzerAsync(source);
+        }
+
+        [Fact]
+        public async Task NoOverridable_DiagnosticReported()
+        {
+            var source = @"
+                namespace ConsoleApplication1
+                {
+                    using Moq;
+                    using System;
+
+                    public class TestClass
+                    {
+                        public void TestMethod()
+                        {
+                            var mock1 = new Mock<StandardClass>();
+                            mock1.Setup(i => i.[|Method|]());
+                            mock1.Setup(i => i.[|Property|]);
+
+                            var mock2 = new Mock<StandardClass>();
+                            mock2.Setup(i => StandardClass.[|StaticMethod|]());
+
+                            var mock3 = new Mock<AbstractClass>();
+                            mock3.Setup(i => i.[|Method|]());
+                            mock3.Setup(i => i.[|Property|]);
+
+                            var mock4 = new Mock<I>();
+                            mock4.Setup(i => i.[|ExtensionMethod|]());
+                        }
+                    }
+
+                    public class StandardClass
+                    {
+                        public void Method() { }
+
+                        public string Property => null;
+
+                        public static void StaticMethod() { }
+                    }
+
+                    public abstract class AbstractClass
+                    {
+                        public void Method() { }
+
+                        public string Property => null;
+                    }
+
+                    public interface I
+                    {
+                        int TestMethod();
+                    }
+
+                    public static class ExtensionsClass
+                    {
+                        public static void ExtensionMethod(this I _) { }
+                    }
+                }
+                " + MoqLibrary.Code;
+
+            await Verify.VerifyAnalyzerAsync(source);
+        }
+
+        [Fact]
+        public async Task NoMoqLibrary()
+        {
+            var source = @"
+                namespace ConsoleApplication1
+                {
+                    using OtherNamespace;
+
+                    public class TestClass
+                    {
+                        public void TestMethod()
+                        {
+                            var mock1 = new Mock<I>(MockBehavior.Strict);
+                        }
+                    }
+
+                    public interface I
+                    {
+                    }
+                }
+
+                namespace OtherNamespace
+                {
+                    public class Mock<T>
+                    {
+                        public Mock(MockBehavior _) { }
+                    }
+
+                    public enum MockBehavior { Strict, Loose }
+                }";
+
+            await Verify.VerifyAnalyzerAsync(source);
+        }
+    }
+}

--- a/tests/Moq.Analyzers.Tests/Analyzers/SetupMustBeUsedOnlyForOverridableMembersAnalyzerTest.cs
+++ b/tests/Moq.Analyzers.Tests/Analyzers/SetupMustBeUsedOnlyForOverridableMembersAnalyzerTest.cs
@@ -40,6 +40,18 @@ namespace PosInformatique.Moq.Analyzers.Tests
                             mock3.Setup(i => i.VirtualProperty);
                             mock3.Setup(i => i.AbstractMethod());
                             mock3.Setup(i => i.AbstractProperty);
+
+                            var mock4 = new Mock<InheritedFromAbstractClass>();
+                            mock4.Setup(i => i.VirtualMethod());
+                            mock4.Setup(i => i.VirtualProperty);
+                            mock4.Setup(i => i.AbstractMethod());
+                            mock4.Setup(i => i.AbstractProperty);
+
+                            var mock5 = new Mock<InheritedFromAbstractClassDontOverrideVirtual>();
+                            mock5.Setup(i => i.VirtualMethod());
+                            mock5.Setup(i => i.VirtualProperty);
+                            mock5.Setup(i => i.AbstractMethod());
+                            mock5.Setup(i => i.AbstractProperty);
                         }
                     }
 
@@ -66,6 +78,24 @@ namespace PosInformatique.Moq.Analyzers.Tests
                         public abstract void AbstractMethod();
 
                         public abstract string AbstractProperty { get; }
+                    }
+
+                    public class InheritedFromAbstractClass : AbstractClass
+                    {
+                        public override void AbstractMethod() { }
+
+                        public override string AbstractProperty => null;
+
+                        public override void VirtualMethod() { }
+
+                        public override string VirtualProperty => null;
+                    }
+
+                    public class InheritedFromAbstractClassDontOverrideVirtual : AbstractClass
+                    {
+                        public override void AbstractMethod() { }
+
+                        public override string AbstractProperty => null;
                     }
                 }
                 " + MoqLibrary.Code;

--- a/tests/Moq.Analyzers.Tests/MoqLibrary.cs
+++ b/tests/Moq.Analyzers.Tests/MoqLibrary.cs
@@ -21,6 +21,8 @@ namespace PosInformatique.Moq.Analyzers.Tests
 
                     public ISetup Setup(Action<T> act) { return null; }
 
+                    public ISetup Setup(Func<T, object> func) { return null; }
+
                     public void VerifyAll() { }
 
                     public void Verify() { }


### PR DESCRIPTION
Add the following rules:
- PosInfoMoq2001: The `Setup()` method must be used only on overridable members. (fixes #4).
- PosInfoMoq2002: `Mock<T>` class can be used only to mock non-sealed class.