### PR TITLE
v1.3.0

### DIFF
--- a/PosInformatique.Moq.Analyzers.sln
+++ b/PosInformatique.Moq.Analyzers.sln
@@ -33,8 +33,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docs", "docs", "{3C20D95F-A
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Design", "Design", "{815BE8D0-C7D5-4B4E-82E0-DE29C11F258E}"
 	ProjectSection(SolutionItems) = preProject
-		docs\design\PosInfoMoq1001.md = docs\design\PosInfoMoq1001.md
 		docs\design\PosInfoMoq1000.md = docs\design\PosInfoMoq1000.md
+		docs\design\PosInfoMoq1001.md = docs\design\PosInfoMoq1001.md
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Compilation", "Compilation", "{D9C84D36-7F9C-4EFB-BE6F-9F7A05FE957D}"
@@ -42,6 +42,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Compilation", "Compilation"
 		docs\Compilation\PosInfoMoq2000.md = docs\Compilation\PosInfoMoq2000.md
 		docs\Compilation\PosInfoMoq2001.md = docs\Compilation\PosInfoMoq2001.md
 		docs\Compilation\PosInfoMoq2002.md = docs\Compilation\PosInfoMoq2002.md
+		docs\Compilation\PosInfoMoq2003.md = docs\Compilation\PosInfoMoq2003.md
 	EndProjectSection
 EndProject
 Global

--- a/README.md
+++ b/README.md
@@ -40,4 +40,5 @@ All the rules of this category should not be disabled (or changed their severity
 | [PosInfoMoq2000: The `Returns()` or `ReturnsAsync()` methods must be call for Strict mocks](docs/Compilation/PosInfoMoq2000.md) | When a `Mock<T>` has been defined with the `Strict` behavior, the `Returns()` or `ReturnsAsync()` method must be called when setup a method to mock which returns a value. |
 | [PosInfoMoq2001: The `Setup()` method must be used only on overridable members](docs/Compilation/PosInfoMoq2001.md)) | The `Setup()` method must be applied only for overridable members. |
 | [PosInfoMoq2002: `Mock<T>` class can be used only to mock non-sealed class](docs/Compilation/PosInfoMoq2002.md) | The `Mock<T>` can mock only interfaces or non-`sealed` classes. |
+| [PosInfoMoq2003: The `Callback()` delegate expression must match the signature of the mocked method](docs/Compilation/PosInfoMoq2003.md) | The delegate in the argument of the `Callback()` method must match the signature of the mocked method. |
 

--- a/build/azure-pipelines-release.yaml
+++ b/build/azure-pipelines-release.yaml
@@ -2,7 +2,7 @@ parameters:
 - name: VersionPrefix
   displayName: The version of the library
   type: string
-  default: 1.2.0
+  default: 1.3.0
 - name: VersionSuffix
   displayName: The version suffix of the library (rc.1). Use a space ' ' if no suffix.
   type: string

--- a/docs/Compilation/PosInfoMoq2003.md
+++ b/docs/Compilation/PosInfoMoq2003.md
@@ -1,0 +1,47 @@
+# PosInfoMoq2003: The `Callback()` delegate expression must match the signature of the mocked method
+
+| Property                            | Value																					|
+|-------------------------------------|-----------------------------------------------------------------------------------------|
+| **Rule ID**                         | PosInfoMoq2003																			|
+| **Title**                           | The `Callback()` delegate expression must match the signature of the mocked method		|
+| **Category**                        | Compilation																				|
+| **Default severity**				  | Error																					|
+
+## Cause
+
+The delegate in the argument of the `Callback()` method must match the signature of the mocked method.
+
+## Rule description
+
+The lambda expression in the argument of the `Callback()` method must match the signature of the mocked method.
+
+For example, the `Callback()` have a lambda expression with the `(string, double)` signature
+which does not match the `GetData()` mocked method which have the `(string, int)` signature.
+
+```csharp
+[Fact]
+public void Test()
+{
+    var service = new Mock<Service>();
+    service.Setup(s => s.GetData("TOURREAU", 1234))
+        .Callback((string n, double age) =>		// Different signature of the GetData() method.
+        {
+        	// ...
+        })
+        .Returns(10);
+}
+
+public interface IService
+{
+	public int GetData(string name, int age) { }
+}
+```
+
+## How to fix violations
+
+To fix a violation of this rule, be sure to use the mocked method signature in the `Callback()` method.
+
+## When to suppress warnings
+
+Do not suppress an error from this rule. If bypassed, the execution of the unit test will be failed with a `MoqException`
+thrown with the *"Invalid callback. Setup on method with parameters (xxx) cannot invoke callback with parameters (yyy)."* message.

--- a/src/Moq.Analyzers/AnalyzerReleases.Shipped.md
+++ b/src/Moq.Analyzers/AnalyzerReleases.Shipped.md
@@ -1,4 +1,12 @@
-﻿## Release 1.2.0
+﻿## Release 1.3.0
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|--------------------
+PosInfoMoq2003  | Compilation | Error  | The `Callback()` delegate expression must match the signature of the mocked method.
+
+## Release 1.2.0
 
 ### New Rules
 

--- a/src/Moq.Analyzers/Analyzers/CallBackDelegateMustMatchMockedMethodAnalyzer.cs
+++ b/src/Moq.Analyzers/Analyzers/CallBackDelegateMustMatchMockedMethodAnalyzer.cs
@@ -95,7 +95,19 @@ namespace PosInformatique.Moq.Analyzers
                 // 2- Iterate for each parameter
                 for (var i = 0; i < callBackLambdaExpressionSymbol.Parameters.Length; i++)
                 {
-                    if (!SymbolEqualityComparer.Default.Equals(callBackLambdaExpressionSymbol.Parameters[i].Type, mockedMethod.Parameters[i].Type))
+                    // Special case, if the argument is IsAnyType
+                    if (moqSymbols.IsAnyType(mockedMethod.Parameters[i].Type))
+                    {
+                        // The callback parameter associated must be an object.
+                        if (callBackLambdaExpressionSymbol.Parameters[i].Type.SpecialType != SpecialType.System_Object)
+                        {
+                            var diagnostic = Diagnostic.Create(Rule, lambdaExpression!.ParameterList.GetLocation());
+                            context.ReportDiagnostic(diagnostic);
+
+                            continue;
+                        }
+                    }
+                    else if (!SymbolEqualityComparer.Default.Equals(callBackLambdaExpressionSymbol.Parameters[i].Type, mockedMethod.Parameters[i].Type))
                     {
                         var diagnostic = Diagnostic.Create(Rule, lambdaExpression!.ParameterList.GetLocation());
                         context.ReportDiagnostic(diagnostic);

--- a/src/Moq.Analyzers/Analyzers/CallBackDelegateMustMatchMockedMethodAnalyzer.cs
+++ b/src/Moq.Analyzers/Analyzers/CallBackDelegateMustMatchMockedMethodAnalyzer.cs
@@ -1,0 +1,109 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="CallBackDelegateMustMatchMockedMethodAnalyzer.cs" company="P.O.S Informatique">
+//     Copyright (c) P.O.S Informatique. All rights reserved.
+// </copyright>
+//-----------------------------------------------------------------------
+
+namespace PosInformatique.Moq.Analyzers
+{
+    using System.Collections.Immutable;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
+    using Microsoft.CodeAnalysis.Diagnostics;
+
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class CallBackDelegateMustMatchMockedMethodAnalyzer : DiagnosticAnalyzer
+    {
+        private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+            "PosInfoMoq2003",
+            "The Callback() delegate expression must match the signature of the mocked method",
+            "The Callback() delegate expression must match the signature of the mocked method",
+            "Compilation",
+            DiagnosticSeverity.Error,
+            isEnabledByDefault: true,
+            description: "The Callback() delegate expression must match the signature of the mocked method.");
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.EnableConcurrentExecution();
+
+            context.RegisterSyntaxNodeAction(Analyze, SyntaxKind.InvocationExpression);
+        }
+
+        private static void Analyze(SyntaxNodeAnalysisContext context)
+        {
+            var invocationExpression = (InvocationExpressionSyntax)context.Node;
+
+            var moqSymbols = MoqSymbols.FromCompilation(context.Compilation);
+
+            if (moqSymbols is null)
+            {
+                return;
+            }
+
+            var moqExpressionAnalyzer = new MoqExpressionAnalyzer(context.SemanticModel);
+
+            // Check is Setup() method.
+            if (!moqExpressionAnalyzer.IsMockSetupMethod(moqSymbols, invocationExpression, out var _))
+            {
+                return;
+            }
+
+            // Check each CallBack() method for the following calls.
+            var followingMethods = invocationExpression.Ancestors().OfType<InvocationExpressionSyntax>();
+
+            foreach (var followingMethod in followingMethods)
+            {
+                var methodSymbol = context.SemanticModel.GetSymbolInfo(followingMethod);
+
+                if (!moqSymbols.IsCallback(methodSymbol.Symbol))
+                {
+                    continue;
+                }
+
+                // Find the symbol of the mocked method (if not symbol found, it is mean we Setup() method that not currently compile)
+                // so we skip the analysis.
+                var mockedMethod = moqExpressionAnalyzer.ExtractSetupMethod(invocationExpression, out var _);
+
+                if (mockedMethod is null)
+                {
+                    continue;
+                }
+
+                // Gets the lambda expression symbol.
+                var callBackLambdaExpressionSymbol = moqExpressionAnalyzer.ExtractCallBackLambdaExpressionMethod(followingMethod, out var lambdaExpression);
+
+                if (callBackLambdaExpressionSymbol is null)
+                {
+                    continue;
+                }
+
+                // Compare the parameters between the mocked method and lambda expression in the CallBack() method.
+                // 1- Compare the number of the parameters
+                if (callBackLambdaExpressionSymbol.Parameters.Length != mockedMethod.Parameters.Length)
+                {
+                    var diagnostic = Diagnostic.Create(Rule, lambdaExpression!.ParameterList.GetLocation());
+                    context.ReportDiagnostic(diagnostic);
+
+                    continue;
+                }
+
+                // 2- Iterate for each parameter
+                for (var i = 0; i < callBackLambdaExpressionSymbol.Parameters.Length; i++)
+                {
+                    if (!SymbolEqualityComparer.Default.Equals(callBackLambdaExpressionSymbol.Parameters[i].Type, mockedMethod.Parameters[i].Type))
+                    {
+                        var diagnostic = Diagnostic.Create(Rule, lambdaExpression!.ParameterList.GetLocation());
+                        context.ReportDiagnostic(diagnostic);
+
+                        continue;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Moq.Analyzers/Moq.Analyzers.csproj
+++ b/src/Moq.Analyzers/Moq.Analyzers.csproj
@@ -33,8 +33,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.7.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.7.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.8.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -42,7 +42,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="Icon.png" Pack="true" PackagePath=""/>
+    <None Include="Icon.png" Pack="true" PackagePath="" />
   </ItemGroup>
 
   <Target Name="_AddAnalyzersToOutput">

--- a/src/Moq.Analyzers/MoqExpressionAnalyzer.cs
+++ b/src/Moq.Analyzers/MoqExpressionAnalyzer.cs
@@ -172,19 +172,19 @@ namespace PosInformatique.Moq.Analyzers
                 return null;
             }
 
-            if (lambdaExpression.Body is not InvocationExpressionSyntax methodExpression)
+            var methodSymbolInfo = this.semanticModel.GetSymbolInfo(lambdaExpression.Body);
+
+            if (methodSymbolInfo.Symbol is IMethodSymbol methodSymbol)
             {
-                return null;
+                return methodSymbol.ReturnType;
             }
 
-            var methodSymbolInfo = this.semanticModel.GetSymbolInfo(methodExpression);
-
-            if (methodSymbolInfo.Symbol is not IMethodSymbol methodSymbol)
+            if (methodSymbolInfo.Symbol is IPropertySymbol propertySymbol)
             {
-                return null;
+                return propertySymbol.Type;
             }
 
-            return methodSymbol.ReturnType;
+            return null;
         }
 
         public ISymbol? ExtractSetupMember(InvocationExpressionSyntax invocationExpression, out NameSyntax? memberIdentifierName)

--- a/src/Moq.Analyzers/MoqExpressionAnalyzer.cs
+++ b/src/Moq.Analyzers/MoqExpressionAnalyzer.cs
@@ -187,6 +187,18 @@ namespace PosInformatique.Moq.Analyzers
             return null;
         }
 
+        public IMethodSymbol? ExtractSetupMethod(InvocationExpressionSyntax invocationExpression, out NameSyntax? memberIdentifierName)
+        {
+            var symbol = this.ExtractSetupMember(invocationExpression, out memberIdentifierName);
+
+            if (symbol is not IMethodSymbol methodSymbol)
+            {
+                return null;
+            }
+
+            return methodSymbol;
+        }
+
         public ISymbol? ExtractSetupMember(InvocationExpressionSyntax invocationExpression, out NameSyntax? memberIdentifierName)
         {
             memberIdentifierName = null;
@@ -229,6 +241,32 @@ namespace PosInformatique.Moq.Analyzers
             var symbol = this.semanticModel.GetSymbolInfo(memberExpression);
 
             return symbol.Symbol;
+        }
+
+        public IMethodSymbol? ExtractCallBackLambdaExpressionMethod(InvocationExpressionSyntax invocationExpression, out ParenthesizedLambdaExpressionSyntax? lambdaExpression)
+        {
+            lambdaExpression = null;
+
+            if (invocationExpression.ArgumentList.Arguments.Count != 1)
+            {
+                return null;
+            }
+
+            if (invocationExpression.ArgumentList.Arguments[0].Expression is not ParenthesizedLambdaExpressionSyntax lambdaExpressionFound)
+            {
+                return null;
+            }
+
+            var symbol = this.semanticModel.GetSymbolInfo(lambdaExpressionFound);
+
+            if (symbol.Symbol is not IMethodSymbol methodSymbol)
+            {
+                return null;
+            }
+
+            lambdaExpression = lambdaExpressionFound;
+
+            return methodSymbol;
         }
 
         private static ObjectCreationExpressionSyntax? FindMockCreation(BlockSyntax block, string variableName)

--- a/src/Moq.Analyzers/MoqSymbols.cs
+++ b/src/Moq.Analyzers/MoqSymbols.cs
@@ -81,6 +81,21 @@ namespace PosInformatique.Moq.Analyzers
             return false;
         }
 
+        public bool IsCallback(ISymbol? symbol)
+        {
+            if (symbol is null)
+            {
+                return false;
+            }
+
+            if (symbol.Name != "Callback")
+            {
+                return false;
+            }
+
+            return true;
+        }
+
         public bool IsReturnsMethod(ISymbol? symbol)
         {
             if (symbol is null)

--- a/src/Moq.Analyzers/MoqSymbols.cs
+++ b/src/Moq.Analyzers/MoqSymbols.cs
@@ -18,10 +18,13 @@ namespace PosInformatique.Moq.Analyzers
 
         private readonly ISymbol mockBehaviorStrictField;
 
-        private MoqSymbols(INamedTypeSymbol mockClass, INamedTypeSymbol mockBehaviorEnum)
+        private readonly ISymbol isAnyTypeClass;
+
+        private MoqSymbols(INamedTypeSymbol mockClass, INamedTypeSymbol mockBehaviorEnum, ISymbol isAnyTypeClass)
         {
             this.mockClass = mockClass;
             this.mockBehaviorEnum = mockBehaviorEnum;
+            this.isAnyTypeClass = isAnyTypeClass;
 
             this.setupMethods = mockClass.GetMembers("Setup").OfType<IMethodSymbol>().ToArray();
             this.mockBehaviorStrictField = mockBehaviorEnum.GetMembers("Strict").First();
@@ -43,7 +46,24 @@ namespace PosInformatique.Moq.Analyzers
                 return null;
             }
 
-            return new MoqSymbols(mockClass, mockBehaviorEnum);
+            var isAnyTypeClass = compilation.GetTypeByMetadataName("Moq.It+IsAnyType");
+
+            if (isAnyTypeClass is null)
+            {
+                return null;
+            }
+
+            return new MoqSymbols(mockClass, mockBehaviorEnum, isAnyTypeClass);
+        }
+
+        public bool IsAnyType(ITypeSymbol symbol)
+        {
+            if (!SymbolEqualityComparer.Default.Equals(symbol, this.isAnyTypeClass))
+            {
+                return false;
+            }
+
+            return true;
         }
 
         public bool IsMock(ISymbol? symbol)

--- a/tests/Moq.Analyzers.Tests/Analyzers/CallBackDelegateMustMatchMockedMethodAnalyzerTest.cs
+++ b/tests/Moq.Analyzers.Tests/Analyzers/CallBackDelegateMustMatchMockedMethodAnalyzerTest.cs
@@ -44,6 +44,16 @@ namespace PosInformatique.Moq.Analyzers.Tests
                                 .Throws()
                                 .Callback((string x, int y) => { })
                                 .Returns();
+                            mock1.Setup(m => m.TestGenericMethod(1234))
+                                .Callback((int x) => { })
+                                .Throws()
+                                .Callback((int x) => { })
+                                .Returns();
+                            mock1.Setup(m => m.TestGenericMethod(It.IsAny<It.IsAnyType>()))
+                                .Callback((object x) => { })
+                                .Throws()
+                                .Callback((object x) => { })
+                                .Returns();
 
                             mock1.Setup(m => m.TestMethodReturn())
                                 .Callback(() => { })
@@ -70,6 +80,8 @@ namespace PosInformatique.Moq.Analyzers.Tests
                         void TestMethod(string a);
 
                         void TestMethod(string a, int b);
+
+                        void TestGenericMethod<T>(T value);
 
                         int TestMethodReturn();
 
@@ -117,6 +129,16 @@ namespace PosInformatique.Moq.Analyzers.Tests
                                 .Throws()
                                 .Callback([|(int too, int much, int parameters)|] => { })
                                 .Returns();
+                            mock1.Setup(m => m.TestGenericMethod(1234))
+                                .Callback([|(string x)|] => { })
+                                .Throws()
+                                .Callback([|(string x)|] => { })
+                                .Returns();
+                            mock1.Setup(m => m.TestGenericMethod(It.IsAny<It.IsAnyType>()))
+                                .Callback([|(string x)|] => { })
+                                .Throws()
+                                .Callback([|(string x)|] => { })
+                                .Returns();
 
                             mock1.Setup(m => m.TestMethodReturn())
                                 .Callback([|(int too, int much, int parameters)|] => { })
@@ -148,6 +170,8 @@ namespace PosInformatique.Moq.Analyzers.Tests
                         void TestMethod(string a);
 
                         void TestMethod(string a, int b);
+
+                        void TestGenericMethod<T>(T value);
 
                         int TestMethodReturn();
 

--- a/tests/Moq.Analyzers.Tests/Analyzers/CallBackDelegateMustMatchMockedMethodAnalyzerTest.cs
+++ b/tests/Moq.Analyzers.Tests/Analyzers/CallBackDelegateMustMatchMockedMethodAnalyzerTest.cs
@@ -1,0 +1,198 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="CallBackDelegateMustMatchMockedMethodAnalyzerTest.cs" company="P.O.S Informatique">
+//     Copyright (c) P.O.S Informatique. All rights reserved.
+// </copyright>
+//-----------------------------------------------------------------------
+
+namespace PosInformatique.Moq.Analyzers.Tests
+{
+    using System.Threading.Tasks;
+    using Xunit;
+    using Verify = Microsoft.CodeAnalysis.CSharp.Testing.CSharpAnalyzerVerifier<
+        CallBackDelegateMustMatchMockedMethodAnalyzer,
+        Microsoft.CodeAnalysis.Testing.DefaultVerifier>;
+
+    public class CallBackDelegateMustMatchMockedMethodAnalyzerTest
+    {
+        [Fact]
+        public async Task CallBackSignatureMatch_NoDiagnosticReported()
+        {
+            var source = @"
+                namespace ConsoleApplication1
+                {
+                    using Moq;
+                    using System;
+
+                    public class TestClass
+                    {
+                        public void TestMethod()
+                        {
+                            var mock1 = new Mock<I>();
+
+                            mock1.Setup(m => m.TestMethod())
+                                .Callback(() => { })
+                                .Throws()
+                                .Callback(() => { })
+                                .Returns();
+                            mock1.Setup(m => m.TestMethod(default))
+                                .Callback((string x) => { })
+                                .Throws()
+                                .Callback((string x) => { })
+                                .Returns();
+                            mock1.Setup(m => m.TestMethod(default, default))
+                                .Callback((string x, int y) => { })
+                                .Throws()
+                                .Callback((string x, int y) => { })
+                                .Returns();
+
+                            mock1.Setup(m => m.TestMethodReturn())
+                                .Callback(() => { })
+                                .Throws()
+                                .Callback(() => { })
+                                .Returns();
+                            mock1.Setup(m => m.TestMethodReturn(default))
+                                .Callback((string x) => { })
+                                .Throws()
+                                .Callback((string x) => { })
+                                .Returns();
+                            mock1.Setup(m => m.TestMethodReturn(default, default))
+                                .Callback((string x, int y) => { })
+                                .Throws()
+                                .Callback((string x, int y) => { })
+                                .Returns();
+                        }
+                    }
+
+                    public interface I
+                    {
+                        void TestMethod();
+
+                        void TestMethod(string a);
+
+                        void TestMethod(string a, int b);
+
+                        int TestMethodReturn();
+
+                        int TestMethodReturn(string a);
+
+                        int TestMethodReturn(string a, int b);
+                    }
+                }
+                " + MoqLibrary.Code;
+
+            await Verify.VerifyAnalyzerAsync(source);
+        }
+
+        [Fact]
+        public async Task CallBackSignatureNotMatch_DiagnosticReported()
+        {
+            var source = @"
+                namespace ConsoleApplication1
+                {
+                    using Moq;
+                    using System;
+
+                    public class TestClass
+                    {
+                        public void TestMethod()
+                        {
+                            var mock1 = new Mock<I>();
+
+                            mock1.Setup(m => m.TestMethod())
+                                .Callback([|(int too, int much, int parameters)|] => { })
+                                .Throws()
+                                .Callback([|(int too, int much, int parameters)|] => { })
+                                .Returns();
+                            mock1.Setup(m => m.TestMethod(default))
+                                .Callback([|()|] => { })
+                                .Throws()
+                                .Callback([|()|] => { })
+                                .Returns();
+                            mock1.Setup(m => m.TestMethod(default))
+                                .Callback([|(int otherType)|] => { })
+                                .Throws()
+                                .Callback([|(int otherType)|] => { });
+                            mock1.Setup(m => m.TestMethod(default))
+                                .Callback([|(int too, int much, int parameters)|] => { })
+                                .Throws()
+                                .Callback([|(int too, int much, int parameters)|] => { })
+                                .Returns();
+
+                            mock1.Setup(m => m.TestMethodReturn())
+                                .Callback([|(int too, int much, int parameters)|] => { })
+                                .Throws()
+                                .Callback([|(int too, int much, int parameters)|] => { })
+                                .Returns();
+                            mock1.Setup(m => m.TestMethodReturn(default))
+                                .Callback([|()|] => { })
+                                .Throws()
+                                .Callback([|()|] => { })
+                                .Returns();
+                            mock1.Setup(m => m.TestMethodReturn(default))
+                                .Callback([|(int otherType)|] => { })
+                                .Throws()
+                                .Callback([|(int otherType)|] => { })
+                                .Returns();
+                            mock1.Setup(m => m.TestMethodReturn(default))
+                                .Callback([|(int too, int much, int parameters)|] => { })
+                                .Throws()
+                                .Callback([|(int too, int much, int parameters)|] => { })
+                                .Returns();
+                        }
+                    }
+
+                    public interface I
+                    {
+                        void TestMethod();
+
+                        void TestMethod(string a);
+
+                        void TestMethod(string a, int b);
+
+                        int TestMethodReturn();
+
+                        int TestMethodReturn(string a);
+
+                        int TestMethodReturn(string a, int b);
+                    }
+                }
+                " + MoqLibrary.Code;
+
+            await Verify.VerifyAnalyzerAsync(source);
+        }
+
+        [Fact]
+        public async Task NoMoqLibrary()
+        {
+            var source = @"
+                namespace ConsoleApplication1
+                {
+                    using OtherNamespace;
+
+                    public class TestClass
+                    {
+                        public void TestMethod()
+                        {
+                            var mock1 = new Mock<I>(MockBehavior.Strict);
+                        }
+                    }
+
+                    public interface I
+                    {
+                    }
+                }
+
+                namespace OtherNamespace
+                {
+                    public class Mock<T>
+                    {
+                        public Mock(MockBehavior _) { }
+                    }
+
+                    public enum MockBehavior { Strict, Loose }
+                }";
+
+            await Verify.VerifyAnalyzerAsync(source);
+        }
+    }
+}

--- a/tests/Moq.Analyzers.Tests/Analyzers/CallBackDelegateMustMatchMockedMethodAnalyzerTest.cs
+++ b/tests/Moq.Analyzers.Tests/Analyzers/CallBackDelegateMustMatchMockedMethodAnalyzerTest.cs
@@ -70,6 +70,12 @@ namespace PosInformatique.Moq.Analyzers.Tests
                                 .Throws()
                                 .Callback((string x, int y) => { })
                                 .Returns();
+
+                            mock1.Setup(m => m.TestMethod(default))
+                                .Callback()
+                                .Throws()
+                                .Callback()
+                                .Returns();
                         }
                     }
 
@@ -121,23 +127,23 @@ namespace PosInformatique.Moq.Analyzers.Tests
                                 .Callback([|()|] => { })
                                 .Returns();
                             mock1.Setup(m => m.TestMethod(default))
-                                .Callback([|(int otherType)|] => { })
+                                .Callback(([|int otherType|]) => { })
                                 .Throws()
-                                .Callback([|(int otherType)|] => { });
+                                .Callback(([|int otherType|]) => { });
                             mock1.Setup(m => m.TestMethod(default))
                                 .Callback([|(int too, int much, int parameters)|] => { })
                                 .Throws()
                                 .Callback([|(int too, int much, int parameters)|] => { })
                                 .Returns();
                             mock1.Setup(m => m.TestGenericMethod(1234))
-                                .Callback([|(string x)|] => { })
+                                .Callback(([|string x|]) => { })
                                 .Throws()
-                                .Callback([|(string x)|] => { })
+                                .Callback(([|string x|]) => { })
                                 .Returns();
                             mock1.Setup(m => m.TestGenericMethod(It.IsAny<It.IsAnyType>()))
-                                .Callback([|(string x)|] => { })
+                                .Callback(([|string x|]) => { })
                                 .Throws()
-                                .Callback([|(string x)|] => { })
+                                .Callback(([|string x|]) => { })
                                 .Returns();
 
                             mock1.Setup(m => m.TestMethodReturn())
@@ -151,9 +157,9 @@ namespace PosInformatique.Moq.Analyzers.Tests
                                 .Callback([|()|] => { })
                                 .Returns();
                             mock1.Setup(m => m.TestMethodReturn(default))
-                                .Callback([|(int otherType)|] => { })
+                                .Callback(([|int otherType|]) => { })
                                 .Throws()
-                                .Callback([|(int otherType)|] => { })
+                                .Callback(([|int otherType|]) => { })
                                 .Returns();
                             mock1.Setup(m => m.TestMethodReturn(default))
                                 .Callback([|(int too, int much, int parameters)|] => { })
@@ -198,20 +204,26 @@ namespace PosInformatique.Moq.Analyzers.Tests
                         public void TestMethod()
                         {
                             var mock1 = new Mock<I>(MockBehavior.Strict);
+                            mock1.Setup(m => m.TestMethod());
                         }
                     }
 
                     public interface I
                     {
+                        void TestMethod();
                     }
                 }
 
                 namespace OtherNamespace
                 {
+                    using System;
+
                     public class Mock<T>
                     {
                         public Mock(MockBehavior _) { }
-                    }
+ 
+                        public void Setup(Action<T> act) { }
+                   }
 
                     public enum MockBehavior { Strict, Loose }
                 }";

--- a/tests/Moq.Analyzers.Tests/Analyzers/MockInstanceShouldBeStrictBehaviorAnalyzerTest.cs
+++ b/tests/Moq.Analyzers.Tests/Analyzers/MockInstanceShouldBeStrictBehaviorAnalyzerTest.cs
@@ -90,16 +90,7 @@ namespace PosInformatique.Moq.Analyzers.Tests
                     {
                     }
                 }
-
-                namespace Moq
-                {
-                    public class Mock<T>
-                    {
-                        public Mock(MockBehavior _) { }
-                    }
-
-                    public enum MockBehavior { Strict, Loose }
-                }";
+                " + MoqLibrary.Code;
 
             await Verify.VerifyAnalyzerAsync(source);
         }
@@ -174,16 +165,7 @@ namespace PosInformatique.Moq.Analyzers.Tests
                     {
                     }
                 }
-
-                namespace Moq
-                {
-                    public class Mock<T>
-                    {
-                        public Mock(MockBehavior _, int a, int b) { }
-                    }
-
-                    public enum MockBehavior { Strict, Loose }
-                }";
+                " + MoqLibrary.Code;
 
             await Verify.VerifyAnalyzerAsync(source);
         }

--- a/tests/Moq.Analyzers.Tests/Analyzers/SetupMethodMustReturnValueWithStrictBehaviorAnalyzerTest.cs
+++ b/tests/Moq.Analyzers.Tests/Analyzers/SetupMethodMustReturnValueWithStrictBehaviorAnalyzerTest.cs
@@ -66,6 +66,20 @@ namespace PosInformatique.Moq.Analyzers.Tests
                                 .Callback()
                                 .ThrowsAsync();
 
+                            var mock8 = new Mock<I>(MockBehavior.Strict);
+                            mock8.Setup(i => i.TestProperty)
+                                .Callback()
+                                .Callback()
+                                .Property
+                                .Returns();
+
+                            var mock9 = new Mock<I>(MockBehavior.Strict);
+                            mock9.Setup(i => i.TestProperty)
+                                .Callback()
+                                .Callback()
+                                .Property
+                                .ReturnsAsync();
+
                             var obj = new object();     // Ignored because not a Mock<T>
                             obj.ToString();
 
@@ -77,6 +91,8 @@ namespace PosInformatique.Moq.Analyzers.Tests
                     public interface I
                     {
                         int TestMethod();
+
+                        int TestProperty { get; set; }
                     }
                 }
                 " + MoqLibrary.Code;
@@ -106,10 +122,18 @@ namespace PosInformatique.Moq.Analyzers.Tests
                                     [|mock1.Setup(i => i.TestMethod())|]
                                         .Callback()
                                         .Callback();
+
+                                    [|mock1.Setup(i => i.TestProperty)|]
+                                        .Callback()
+                                        .Callback();
                                 }
                             }
 
                             [|mock2.Setup(i => i.TestMethod())|]
+                                .Callback()
+                                .Callback();
+
+                            [|mock2.Setup(i => i.TestProperty)|]
                                 .Callback()
                                 .Callback();
                         }
@@ -118,6 +142,8 @@ namespace PosInformatique.Moq.Analyzers.Tests
                     public interface I
                     {
                         int TestMethod();
+
+                        int TestProperty { get; set; }
                     }
                 }
                 " + MoqLibrary.Code;
@@ -141,12 +167,17 @@ namespace PosInformatique.Moq.Analyzers.Tests
                             [|mock1.Setup(i => i.TestMethod())|]
                                 .Callback()
                                 .Callback();
+                            [|mock1.Setup(i => i.TestProperty)|]
+                                .Callback()
+                                .Callback();
                         }
                     }
 
                     public interface I
                     {
                         int TestMethod();
+
+                        int TestProperty { get; set; }
                     }
                 }
                 "
@@ -176,12 +207,19 @@ namespace PosInformatique.Moq.Analyzers.Tests
                             mock1.Setup(i => i.TestMethod())
                                 .Callback()
                                 .Callback();
+
+                            var mock2 = new Mock<I>("" + mockArguments + @"");
+                            mock2.Setup(i => i.TestProperty)
+                                .Callback()
+                                .Callback();
                         }
                     }
 
                     public interface I
                     {
                         int TestMethod();
+
+                        int TestProperty { get; set; }
                     }
 
                     public enum OtherEnum { A, B }

--- a/tests/Moq.Analyzers.Tests/CodeFixes/SetBehaviorToStrictCodeFixProviderTest.cs
+++ b/tests/Moq.Analyzers.Tests/CodeFixes/SetBehaviorToStrictCodeFixProviderTest.cs
@@ -35,30 +35,7 @@ namespace PosInformatique.Moq.Analyzers.Tests
                     {
                     }
                 }
-
-                namespace Moq
-                {
-                    public class Mock<T>
-                    {
-                        public Mock(MockBehavior _, params object[] args)
-                        {
-                        }
-
-                        public Mock(MockBehavior _)
-                        {
-                        }
-
-                        public Mock(params object[] args)
-                        {
-                        }
-
-                        public Mock()
-                        {
-                        }
-                    }
-
-                    public enum MockBehavior { Strict, Loose }
-                }";
+                " + MoqLibrary.Code;
 
             var expectedFixedSource =
             @"
@@ -78,30 +55,7 @@ namespace PosInformatique.Moq.Analyzers.Tests
                     {
                     }
                 }
-
-                namespace Moq
-                {
-                    public class Mock<T>
-                    {
-                        public Mock(MockBehavior _, params object[] args)
-                        {
-                        }
-
-                        public Mock(MockBehavior _)
-                        {
-                        }
-
-                        public Mock(params object[] args)
-                        {
-                        }
-
-                        public Mock()
-                        {
-                        }
-                    }
-
-                    public enum MockBehavior { Strict, Loose }
-                }";
+                " + MoqLibrary.Code;
 
             await Verify.VerifyCodeFixAsync(source, expectedFixedSource);
         }
@@ -127,30 +81,7 @@ namespace PosInformatique.Moq.Analyzers.Tests
                     {
                     }
                 }
-
-                namespace Moq
-                {
-                    public class Mock<T>
-                    {
-                        public Mock(MockBehavior _, params object[] args)
-                        {
-                        }
-
-                        public Mock(MockBehavior _)
-                        {
-                        }
-
-                        public Mock(params object[] args)
-                        {
-                        }
-
-                        public Mock()
-                        {
-                        }
-                    }
-
-                    public enum MockBehavior { Strict, Loose }
-                }";
+                " + MoqLibrary.Code;
 
             var expectedFixedSource =
             @"
@@ -171,30 +102,7 @@ namespace PosInformatique.Moq.Analyzers.Tests
                     {
                     }
                 }
-
-                namespace Moq
-                {
-                    public class Mock<T>
-                    {
-                        public Mock(MockBehavior _, params object[] args)
-                        {
-                        }
-
-                        public Mock(MockBehavior _)
-                        {
-                        }
-
-                        public Mock(params object[] args)
-                        {
-                        }
-
-                        public Mock()
-                        {
-                        }
-                    }
-
-                    public enum MockBehavior { Strict, Loose }
-                }";
+                " + MoqLibrary.Code;
 
             await Verify.VerifyCodeFixAsync(source, expectedFixedSource);
         }
@@ -224,30 +132,7 @@ namespace PosInformatique.Moq.Analyzers.Tests
 
                     public enum OtherEnum { A }
                 }
-
-                namespace Moq
-                {
-                    public class Mock<T>
-                    {
-                        public Mock(MockBehavior _, params object[] args)
-                        {
-                        }
-
-                        public Mock(MockBehavior _)
-                        {
-                        }
-
-                        public Mock(params object[] args)
-                        {
-                        }
-
-                        public Mock()
-                        {
-                        }
-                    }
-
-                    public enum MockBehavior { Strict, Loose }
-                }";
+                " + MoqLibrary.Code;
 
             var expectedFixedSource =
             @"
@@ -272,30 +157,7 @@ namespace PosInformatique.Moq.Analyzers.Tests
 
                     public enum OtherEnum { A }
                 }
-
-                namespace Moq
-                {
-                    public class Mock<T>
-                    {
-                        public Mock(MockBehavior _, params object[] args)
-                        {
-                        }
-
-                        public Mock(MockBehavior _)
-                        {
-                        }
-
-                        public Mock(params object[] args)
-                        {
-                        }
-
-                        public Mock()
-                        {
-                        }
-                    }
-
-                    public enum MockBehavior { Strict, Loose }
-                }";
+                " + MoqLibrary.Code;
 
             await Verify.VerifyCodeFixAsync(source, expectedFixedSource);
         }

--- a/tests/Moq.Analyzers.Tests/Moq.Analyzers.Tests.csproj
+++ b/tests/Moq.Analyzers.Tests/Moq.Analyzers.Tests.csproj
@@ -12,10 +12,10 @@
 		<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		<PrivateAssets>all</PrivateAssets>
 	</PackageReference>
-	<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.7.0" />
+	<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.8.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" Version="1.1.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" Version="1.1.1" />
-	<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+	<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
 	<PackageReference Include="xunit" Version="2.5.1" />
 	<PackageReference Include="xunit.runner.visualstudio" Version="2.5.1">
 		<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/Moq.Analyzers.Tests/MoqLibrary.cs
+++ b/tests/Moq.Analyzers.Tests/MoqLibrary.cs
@@ -38,6 +38,20 @@ namespace PosInformatique.Moq.Analyzers.Tests
                 {
                     ISetup Callback();
 
+                    ISetup Callback(Action _);
+
+                    ISetup Callback<T1>(Action<T1> _);
+
+                    ISetup Callback<T1, T2>(Action<T1, T2> _);
+
+                    ISetup Callback<T1, T2, T3>(Action<T1, T2, T3> _);
+
+                    ISetup Callback<T1, TReturn>(Func<T1, TReturn> _);
+
+                    ISetup Callback<T1, T2, TReturn>(Func<T1, T2, TReturn> _);
+
+                    ISetup Callback<T1, T2, T3, TReturn>(Func<T1, T2, T3, TReturn> _);
+
                     ISetup Property { get; }
 
                     ISetup Returns();

--- a/tests/Moq.Analyzers.Tests/MoqLibrary.cs
+++ b/tests/Moq.Analyzers.Tests/MoqLibrary.cs
@@ -62,6 +62,15 @@ namespace PosInformatique.Moq.Analyzers.Tests
 
                     ISetup ThrowsAsync();
                 }
+
+                public static class It
+                {
+                    public static TValue IsAny<TValue>() { return default; }
+
+                    public sealed class IsAnyType
+                    {
+                    }
+                }
             }";
     }
 }


### PR DESCRIPTION
- Add a new **PosInfoMoq2003** rule to check the `Callback()` signature method (fixes #3).
- Fixes the **PosInfoMoq2000** rule to check the call of the `Returns()`/`ReturnsAsync()` methods for the mocked properties for the mock with `Strict` behavior. (fixes #6)