### PR TITLE
v1.4.0

### DIFF
--- a/build/azure-pipelines-release.yaml
+++ b/build/azure-pipelines-release.yaml
@@ -2,7 +2,7 @@ parameters:
 - name: VersionPrefix
   displayName: The version of the library
   type: string
-  default: 1.3.0
+  default: 1.4.0
 - name: VersionSuffix
   displayName: The version suffix of the library (rc.1). Use a space ' ' if no suffix.
   type: string

--- a/src/Moq.Analyzers/Moq.Analyzers.csproj
+++ b/src/Moq.Analyzers/Moq.Analyzers.csproj
@@ -33,8 +33,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.8.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.0.1" />
   </ItemGroup>
 
   <ItemGroup>
@@ -43,6 +43,11 @@
 
   <ItemGroup>
     <None Include="Icon.png" Pack="true" PackagePath="" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <AdditionalFiles Include="AnalyzerReleases.Shipped.md" />
+    <AdditionalFiles Include="AnalyzerReleases.Unshipped.md" />
   </ItemGroup>
 
   <Target Name="_AddAnalyzersToOutput">

--- a/src/Moq.Analyzers/Moq.Analyzers.csproj
+++ b/src/Moq.Analyzers/Moq.Analyzers.csproj
@@ -17,15 +17,18 @@
     <PackageProjectUrl>https://github.com/PosInformatique/PosInformatique.Moq.Analyzers</PackageProjectUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>
+      1.4.0
+      - Reduce the dependency of Microsoft.CodeAnalysis.CSharp to the release 4.0.1.
+
       1.3.0
       - Add new rules:
-        - PosInfoMoq2003 rule to check the Callback() signature method (fixes #3).
+      - PosInfoMoq2003 rule to check the Callback() signature method (fixes #3).
       - Fixes the PosInfoMoq2000 rule to check the call of the Returns()/ReturnsAsync() methods for the mocked properties for the mock with Strict behavior.
-      
+
       1.2.0
       - Add new rules:
-        - PosInfoMoq2001: The Setup() method must be used only on overridable members.
-        - PosInfoMoq2002: Mock&lt;T&gt; class can be used only to mock non-sealed class.
+      - PosInfoMoq2001: The Setup() method must be used only on overridable members.
+      - PosInfoMoq2002: Mock&lt;T&gt; class can be used only to mock non-sealed class.
       
       1.1.0
       - Add new rules:

--- a/src/Moq.Analyzers/Moq.Analyzers.csproj
+++ b/src/Moq.Analyzers/Moq.Analyzers.csproj
@@ -17,9 +17,19 @@
     <PackageProjectUrl>https://github.com/PosInformatique/PosInformatique.Moq.Analyzers</PackageProjectUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>
+      1.3.0
+      - Add new rules:
+        - PosInfoMoq2003 rule to check the Callback() signature method (fixes #3).
+      - Fixes the PosInfoMoq2000 rule to check the call of the Returns()/ReturnsAsync() methods for the mocked properties for the mock with Strict behavior.
+      
+      1.2.0
+      - Add new rules:
+        - PosInfoMoq2001: The Setup() method must be used only on overridable members.
+        - PosInfoMoq2002: Mock&lt;T&gt; class can be used only to mock non-sealed class.
+      
       1.1.0
       - Add new rules:
-        - PosInfoMoq2000: The `Returns()` or `ReturnsAsync()` methods must be call for Strict mocks.
+        - PosInfoMoq2000: The Returns() or ReturnsAsync() methods must be call for Strict mocks.
 
       1.0.0
       - Initial version with the followings rules:


### PR DESCRIPTION
- Reduce the dependency of Microsoft.CodeAnalysis.CSharp to the release 4.0.1 (allows developper to use the analyzers with old version of the C# compiler).