### PR TITLE
v1.6.0

### DIFF
--- a/.github/workflows/github-actions-release.yml
+++ b/.github/workflows/github-actions-release.yml
@@ -7,7 +7,7 @@ on:
         type: string
         description: The version of the library
         required: true
-        default: 1.5.0
+        default: 1.6.0
       VersionSuffix:
         type: string
         description: The version suffix of the library (for example rc.1)

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -34,7 +34,7 @@
   
   <!-- Common NuGet packages -->
   <ItemGroup>
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/PosInformatique.Moq.Analyzers.sln
+++ b/PosInformatique.Moq.Analyzers.sln
@@ -41,6 +41,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Compilation", "Compilation"
 		docs\Compilation\PosInfoMoq2005.md = docs\Compilation\PosInfoMoq2005.md
 		docs\Compilation\PosInfoMoq2006.md = docs\Compilation\PosInfoMoq2006.md
 		docs\Compilation\PosInfoMoq2007.md = docs\Compilation\PosInfoMoq2007.md
+		docs\Compilation\PosInfoMoq2008.md = docs\Compilation\PosInfoMoq2008.md
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Moq.Analyzers.Sandbox", "tests\Moq.Analyzers.Sandbox\Moq.Analyzers.Sandbox.csproj", "{07F970A1-1477-4D4C-B233-C9B4DA6E3AD6}"

--- a/PosInformatique.Moq.Analyzers.sln
+++ b/PosInformatique.Moq.Analyzers.sln
@@ -40,6 +40,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Compilation", "Compilation"
 		docs\Compilation\PosInfoMoq2004.md = docs\Compilation\PosInfoMoq2004.md
 		docs\Compilation\PosInfoMoq2005.md = docs\Compilation\PosInfoMoq2005.md
 		docs\Compilation\PosInfoMoq2006.md = docs\Compilation\PosInfoMoq2006.md
+		docs\Compilation\PosInfoMoq2007.md = docs\Compilation\PosInfoMoq2007.md
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Moq.Analyzers.Sandbox", "tests\Moq.Analyzers.Sandbox\Moq.Analyzers.Sandbox.csproj", "{07F970A1-1477-4D4C-B233-C9B4DA6E3AD6}"

--- a/README.md
+++ b/README.md
@@ -44,4 +44,6 @@ All the rules of this category should not be disabled (or changed their severity
 | [PosInfoMoq2004: Constructor arguments cannot be passed for interface mocks](docs/Compilation/PosInfoMoq2004.md) | No arguments can be passed to a mocked interface. |
 | [PosInfoMoq2005: Constructor arguments must match the constructors of the mocked class](docs/Compilation/PosInfoMoq2005.md) | When instantiating a `Mock<T>`, the parameters must match one of the constructors of the mocked type.  |
 | [PosInfoMoq2006: The Protected().Setup() method must be use with overridable protected or internal methods](docs/Compilation/PosInfoMoq2006.md) | When using the `Protected().Setup()` configuration, the method mocked must be overridable and protected or internal. |
+| [PosInfoMoq2007: The `As<T>()` method can be used only with interfaces.](docs/Compilation/PosInfoMoq2007.md) | The `As<T>()` can only be use with the interfaces. |
+
 

--- a/README.md
+++ b/README.md
@@ -45,5 +45,7 @@ All the rules of this category should not be disabled (or changed their severity
 | [PosInfoMoq2005: Constructor arguments must match the constructors of the mocked class](docs/Compilation/PosInfoMoq2005.md) | When instantiating a `Mock<T>`, the parameters must match one of the constructors of the mocked type.  |
 | [PosInfoMoq2006: The Protected().Setup() method must be use with overridable protected or internal methods](docs/Compilation/PosInfoMoq2006.md) | When using the `Protected().Setup()` configuration, the method mocked must be overridable and protected or internal. |
 | [PosInfoMoq2007: The `As<T>()` method can be used only with interfaces.](docs/Compilation/PosInfoMoq2007.md) | The `As<T>()` can only be use with the interfaces. |
+| [PosInfoMoq2008: The `Verify()` method must be used only on overridable members](docs/Compilation/PosInfoMoq2008.md)) | The `Verify()` method must be applied only for overridable members. |
+
 
 

--- a/docs/Compilation/PosInfoMoq2006.md
+++ b/docs/Compilation/PosInfoMoq2006.md
@@ -23,7 +23,7 @@ and must be overridable (`virtual`, `abstract` and `override`, but not `sealed`)
 [Fact]
 public void Test()
 {
-    var service = new Mock<Service>(1, 2, 3);
+    var service = new Mock<Service>();
     service.Protected().Setup("GetData")            // The GetData() is public and can be mocked with Protected() feature.
         .Returns(10);
     service.Protected().Setup("NotExists")          // The NotExists() method does not exist.

--- a/docs/Compilation/PosInfoMoq2007.md
+++ b/docs/Compilation/PosInfoMoq2007.md
@@ -1,0 +1,45 @@
+# PosInfoMoq2007: The `As<T>()` method can be used only with interfaces.
+
+| Property                            | Value															|
+|-------------------------------------|-----------------------------------------------------------------|
+| **Rule ID**                         | PosInfoMoq2007													|
+| **Title**                           | The `As<T>()` method can be used only with interfaces.          |
+| **Category**                        | Compilation														|
+| **Default severity**				  | Error															|
+
+## Cause
+
+The `As<T>()` method is used with a type which is not an interface.
+
+## Rule description
+
+Moq allows to add additional implementations for mocked class (or interface) by adding additional interfaces
+with the `As<T>()` method.
+
+```csharp
+[Fact]
+public void Test()
+{
+    var service = new Mock<Service>();
+    service.As<IDisposable>()           // Add IDisposable implementation for the mocked Service class.
+        .Setup(s => s.Dispose());
+    service.As<OtherService>();         // An error will be raised, because we can't mock additional implementation of a class.
+}
+
+public abstract class Service
+{
+}
+
+public abstract class OtherService
+{
+}
+```
+
+## How to fix violations
+
+To fix a violation of this rule, use an interface when using the `As<T>()` method.
+
+## When to suppress warnings
+
+Do not suppress an error from this rule. If bypassed, the execution of the unit test will be failed with a `MoqException`
+thrown with the *"Can only add interfaces to the mock."* message.

--- a/docs/Compilation/PosInfoMoq2008.md
+++ b/docs/Compilation/PosInfoMoq2008.md
@@ -1,15 +1,15 @@
-# PosInfoMoq2001: The `Setup()` method must be used only on overridable members
+# PosInfoMoq2008: The `Verify()` method must be used only on overridable members
 
 | Property                            | Value                                                         |
 |-------------------------------------|---------------------------------------------------------------|
-| **Rule ID**                         | PosInfoMoq2001                                                |
-| **Title**                           | The `Setup()` method must be used only on overridable members |
+| **Rule ID**                         | PosInfoMoq2008                                                |
+| **Title**                           | The `Verify()` method must be used only on overridable members |
 | **Category**                        | Compilation													  |
 | **Default severity**				  | Error														  |
 
 ## Cause
 
-The `Setup()` method must be applied only for overridable members.
+The `Verify()` method must be applied only for overridable members.
 An overridable member is a **method** or **property** which is in:
 - An `interface`.
 - A non-`sealed` `class`. In this case, the member must be:
@@ -18,9 +18,9 @@ An overridable member is a **method** or **property** which is in:
 
 ## Rule description
 
-The `Setup()` method must be applied only for overridable members.
+The `Verify()` method must be applied only for overridable members.
 
-For example, the following methods and properties can be mock and used in the `Setup()` method:
+For example, the following methods and properties can be mock and used in the `Verify()` method:
 - `IService.MethodCanBeMocked()`
 - `IService.PropertyCanBeMocked`
 - `Service.VirtualMethodCanBeMocked`
@@ -53,7 +53,7 @@ static methods which can not be overriden.
 
 ## How to fix violations
 
-To fix a violation of this rule, be sure to mock a member in the `Setup()` method which can be overriden.
+To fix a violation of this rule, be sure to mock a member in the `Verify()` method which can be overriden.
 
 ## When to suppress warnings
 

--- a/src/Moq.Analyzers/AnalyzerReleases.Shipped.md
+++ b/src/Moq.Analyzers/AnalyzerReleases.Shipped.md
@@ -5,6 +5,7 @@
 Rule ID | Category | Severity | Notes
 --------|----------|----------|--------------------
 PosInfoMoq2007 | Compilation | Error | The `As<T>()` method can be used only with interfaces.
+PosInfoMoq2008 | Compilation | Error | The `Verify()` method can be used only on overridable members.
 
 ## Release 1.5.0
 

--- a/src/Moq.Analyzers/AnalyzerReleases.Shipped.md
+++ b/src/Moq.Analyzers/AnalyzerReleases.Shipped.md
@@ -1,4 +1,12 @@
-﻿## Release 1.5.0
+﻿## Release 1.6.0
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|--------------------
+PosInfoMoq2007 | Compilation | Error | The `As<T>()` method can be used only with interfaces.
+
+## Release 1.5.0
 
 ### New Rules
 

--- a/src/Moq.Analyzers/Analyzers/AsMustBeUsedWithInterfaceAnalyzer.cs
+++ b/src/Moq.Analyzers/Analyzers/AsMustBeUsedWithInterfaceAnalyzer.cs
@@ -22,7 +22,8 @@ namespace PosInformatique.Moq.Analyzers
             "Compilation",
             DiagnosticSeverity.Error,
             isEnabledByDefault: true,
-            description: "The As<T>() method can be used only with interfaces.");
+            description: "The As<T>() method can be used only with interfaces.",
+            helpLinkUri: "https://posinformatique.github.io/PosInformatique.Moq.Analyzers/docs/Compilation/PosInfoMoq2007.html");
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 

--- a/src/Moq.Analyzers/Analyzers/AsMustBeUsedWithInterfaceAnalyzer.cs
+++ b/src/Moq.Analyzers/Analyzers/AsMustBeUsedWithInterfaceAnalyzer.cs
@@ -45,9 +45,9 @@ namespace PosInformatique.Moq.Analyzers
                 return;
             }
 
-            var moqExpressionAnalyzer = new MoqExpressionAnalyzer(context.SemanticModel);
+            var moqExpressionAnalyzer = new MoqExpressionAnalyzer(moqSymbols, context.SemanticModel);
 
-            var asMethodType = moqExpressionAnalyzer.ExtractAsMethodType(moqSymbols, invocationExpression, out var typeSyntax, context.CancellationToken);
+            var asMethodType = moqExpressionAnalyzer.ExtractAsMethodType(invocationExpression, out var typeSyntax, context.CancellationToken);
 
             if (asMethodType is null)
             {

--- a/src/Moq.Analyzers/Analyzers/AsMustBeUsedWithInterfaceAnalyzer.cs
+++ b/src/Moq.Analyzers/Analyzers/AsMustBeUsedWithInterfaceAnalyzer.cs
@@ -1,0 +1,66 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="AsMustBeUsedWithInterfaceAnalyzer.cs" company="P.O.S Informatique">
+//     Copyright (c) P.O.S Informatique. All rights reserved.
+// </copyright>
+//-----------------------------------------------------------------------
+
+namespace PosInformatique.Moq.Analyzers
+{
+    using System.Collections.Immutable;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
+    using Microsoft.CodeAnalysis.Diagnostics;
+
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class AsMustBeUsedWithInterfaceAnalyzer : DiagnosticAnalyzer
+    {
+        internal static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+            "PosInfoMoq2007",
+            "The As<T>() method can be used only with interfaces",
+            "The As<T>() method can be used only with interfaces",
+            "Compilation",
+            DiagnosticSeverity.Error,
+            isEnabledByDefault: true,
+            description: "The As<T>() method can be used only with interfaces.");
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.EnableConcurrentExecution();
+
+            context.RegisterSyntaxNodeAction(Analyze, SyntaxKind.InvocationExpression);
+        }
+
+        private static void Analyze(SyntaxNodeAnalysisContext context)
+        {
+            var invocationExpression = (InvocationExpressionSyntax)context.Node;
+
+            var moqSymbols = MoqSymbols.FromCompilation(context.Compilation);
+
+            if (moqSymbols is null)
+            {
+                return;
+            }
+
+            var moqExpressionAnalyzer = new MoqExpressionAnalyzer(context.SemanticModel);
+
+            var asMethodType = moqExpressionAnalyzer.ExtractAsMethodType(moqSymbols, invocationExpression, out var typeSyntax, context.CancellationToken);
+
+            if (asMethodType is null)
+            {
+                return;
+            }
+
+            if (asMethodType.TypeKind == TypeKind.Interface)
+            {
+                return;
+            }
+
+            var diagnostic = Diagnostic.Create(Rule, typeSyntax!.GetLocation());
+            context.ReportDiagnostic(diagnostic);
+        }
+    }
+}

--- a/src/Moq.Analyzers/Analyzers/CallBackDelegateMustMatchMockedMethodAnalyzer.cs
+++ b/src/Moq.Analyzers/Analyzers/CallBackDelegateMustMatchMockedMethodAnalyzer.cs
@@ -71,6 +71,11 @@ namespace PosInformatique.Moq.Analyzers
             {
                 // Find the symbol of the mocked method (if not symbol found, it is mean we Setup() method that not currently compile)
                 // so we skip the analysis.
+                if (!moqExpressionAnalyzer.IsMockSetupMethod(followingMethod, out var _, context.CancellationToken))
+                {
+                    continue;
+                }
+
                 var mockedMethod = moqExpressionAnalyzer.ExtractSetupMethod(followingMethod, out var _, context.CancellationToken);
 
                 if (mockedMethod is null)

--- a/src/Moq.Analyzers/Analyzers/CallBackDelegateMustMatchMockedMethodAnalyzer.cs
+++ b/src/Moq.Analyzers/Analyzers/CallBackDelegateMustMatchMockedMethodAnalyzer.cs
@@ -22,7 +22,8 @@ namespace PosInformatique.Moq.Analyzers
             "Compilation",
             DiagnosticSeverity.Error,
             isEnabledByDefault: true,
-            description: "The Callback() delegate expression must match the signature of the mocked method.");
+            description: "The Callback() delegate expression must match the signature of the mocked method.",
+            helpLinkUri: "https://posinformatique.github.io/PosInformatique.Moq.Analyzers/docs/Compilation/PosInfoMoq2003.html");
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 

--- a/src/Moq.Analyzers/Analyzers/CallBackDelegateMustMatchMockedMethodAnalyzer.cs
+++ b/src/Moq.Analyzers/Analyzers/CallBackDelegateMustMatchMockedMethodAnalyzer.cs
@@ -45,8 +45,6 @@ namespace PosInformatique.Moq.Analyzers
                 return;
             }
 
-            var moqExpressionAnalyzer = new MoqExpressionAnalyzer(context.SemanticModel);
-
             // Try to determine if the invocation expression is a Callback() expression.
             var methodSymbol = context.SemanticModel.GetSymbolInfo(invocationExpression, context.CancellationToken);
 
@@ -56,6 +54,8 @@ namespace PosInformatique.Moq.Analyzers
             }
 
             // If yes, we extract the lambda expression of it.
+            var moqExpressionAnalyzer = new MoqExpressionAnalyzer(moqSymbols, context.SemanticModel);
+
             var callBackLambdaExpressionSymbol = moqExpressionAnalyzer.ExtractCallBackLambdaExpressionMethod(invocationExpression, out var lambdaExpression, context.CancellationToken);
 
             if (callBackLambdaExpressionSymbol is null)

--- a/src/Moq.Analyzers/Analyzers/ConstructorArgumentCannotBePassedForInterfaceAnalyzer.cs
+++ b/src/Moq.Analyzers/Analyzers/ConstructorArgumentCannotBePassedForInterfaceAnalyzer.cs
@@ -22,7 +22,8 @@ namespace PosInformatique.Moq.Analyzers
             "Compilation",
             DiagnosticSeverity.Error,
             isEnabledByDefault: true,
-            description: "Constructor arguments cannot be passed for interface mocks.");
+            description: "Constructor arguments cannot be passed for interface mocks.",
+            helpLinkUri: "https://posinformatique.github.io/PosInformatique.Moq.Analyzers/docs/Compilation/PosInfoMoq2004.html");
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 

--- a/src/Moq.Analyzers/Analyzers/ConstructorArgumentCannotBePassedForInterfaceAnalyzer.cs
+++ b/src/Moq.Analyzers/Analyzers/ConstructorArgumentCannotBePassedForInterfaceAnalyzer.cs
@@ -45,10 +45,10 @@ namespace PosInformatique.Moq.Analyzers
                 return;
             }
 
-            var moqExpressionAnalyzer = new MoqExpressionAnalyzer(context.SemanticModel);
+            var moqExpressionAnalyzer = new MoqExpressionAnalyzer(moqSymbols, context.SemanticModel);
 
             // Check there is "new Mock<I>()" statement.
-            var mockedType = moqExpressionAnalyzer.GetMockedType(moqSymbols, objectCreation, out var typeExpression, context.CancellationToken);
+            var mockedType = moqExpressionAnalyzer.GetMockedType(objectCreation, out var typeExpression, context.CancellationToken);
             if (mockedType is null)
             {
                 return;
@@ -77,7 +77,7 @@ namespace PosInformatique.Moq.Analyzers
             // Check if the first argument is MockBehavior argument
             var argumentCheckStart = 0;
 
-            if (moqExpressionAnalyzer.IsStrictBehaviorArgument(moqSymbols, firstArgument, out var _, context.CancellationToken))
+            if (moqExpressionAnalyzer.IsStrictBehaviorArgument(firstArgument, out var _, context.CancellationToken))
             {
                 argumentCheckStart = 1;
             }

--- a/src/Moq.Analyzers/Analyzers/ConstructorArgumentsMustMatchAnalyzer.cs
+++ b/src/Moq.Analyzers/Analyzers/ConstructorArgumentsMustMatchAnalyzer.cs
@@ -23,7 +23,8 @@ namespace PosInformatique.Moq.Analyzers
             "Compilation",
             DiagnosticSeverity.Error,
             isEnabledByDefault: true,
-            description: "Constructor arguments must match the constructors of the mocked class.");
+            description: "Constructor arguments must match the constructors of the mocked class.",
+            helpLinkUri: "https://posinformatique.github.io/PosInformatique.Moq.Analyzers/docs/Compilation/PosInfoMoq2005.html");
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 

--- a/src/Moq.Analyzers/Analyzers/ConstructorArgumentsMustMatchAnalyzer.cs
+++ b/src/Moq.Analyzers/Analyzers/ConstructorArgumentsMustMatchAnalyzer.cs
@@ -46,10 +46,10 @@ namespace PosInformatique.Moq.Analyzers
                 return;
             }
 
-            var moqExpressionAnalyzer = new MoqExpressionAnalyzer(context.SemanticModel);
+            var moqExpressionAnalyzer = new MoqExpressionAnalyzer(moqSymbols, context.SemanticModel);
 
             // Check there is "new Mock<I>()" statement.
-            var mockedType = moqExpressionAnalyzer.GetMockedType(moqSymbols, objectCreation, out var _, context.CancellationToken);
+            var mockedType = moqExpressionAnalyzer.GetMockedType(objectCreation, out var _, context.CancellationToken);
             if (mockedType is null)
             {
                 return;
@@ -80,7 +80,7 @@ namespace PosInformatique.Moq.Analyzers
 
             if (firstArgument is not null)
             {
-                if (moqExpressionAnalyzer.IsStrictBehaviorArgument(moqSymbols, firstArgument, out var _, context.CancellationToken))
+                if (moqExpressionAnalyzer.IsStrictBehaviorArgument(firstArgument, out var _, context.CancellationToken))
                 {
                     constructorArguments.RemoveAt(0);
                 }

--- a/src/Moq.Analyzers/Analyzers/MockInstanceShouldBeStrictBehaviorAnalyzer.cs
+++ b/src/Moq.Analyzers/Analyzers/MockInstanceShouldBeStrictBehaviorAnalyzer.cs
@@ -47,15 +47,15 @@ namespace PosInformatique.Moq.Analyzers
                 return;
             }
 
-            var moqExpressionAnalyzer = new MoqExpressionAnalyzer(context.SemanticModel);
+            var moqExpressionAnalyzer = new MoqExpressionAnalyzer(moqSymbols, context.SemanticModel);
 
             // Check there is "new Mock<I>()" statement.
-            if (!moqExpressionAnalyzer.IsMockCreation(moqSymbols, objectCreation, context.CancellationToken))
+            if (!moqExpressionAnalyzer.IsMockCreation(objectCreation, context.CancellationToken))
             {
                 return;
             }
 
-            if (!moqExpressionAnalyzer.IsStrictBehavior(moqSymbols, objectCreation, context.CancellationToken))
+            if (!moqExpressionAnalyzer.IsStrictBehavior(objectCreation, context.CancellationToken))
             {
                 var diagnostic = Diagnostic.Create(Rule, objectCreation.GetLocation());
                 context.ReportDiagnostic(diagnostic);

--- a/src/Moq.Analyzers/Analyzers/MockInstanceShouldBeStrictBehaviorAnalyzer.cs
+++ b/src/Moq.Analyzers/Analyzers/MockInstanceShouldBeStrictBehaviorAnalyzer.cs
@@ -24,7 +24,8 @@ namespace PosInformatique.Moq.Analyzers
             "Design",
             DiagnosticSeverity.Warning,
             isEnabledByDefault: true,
-            description: "The Mock<T> instance behavior should be defined to Strict mode.");
+            description: "The Mock<T> instance behavior should be defined to Strict mode.",
+            helpLinkUri: "https://posinformatique.github.io/PosInformatique.Moq.Analyzers/docs/Design/PosInfoMoq1001.html");
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 

--- a/src/Moq.Analyzers/Analyzers/NoSealedClassAnalyzer.cs
+++ b/src/Moq.Analyzers/Analyzers/NoSealedClassAnalyzer.cs
@@ -22,7 +22,8 @@ namespace PosInformatique.Moq.Analyzers
             "Compilation",
             DiagnosticSeverity.Error,
             isEnabledByDefault: true,
-            description: "Mock<T> class can be used only to mock non-sealed class.");
+            description: "Mock<T> class can be used only to mock non-sealed class.",
+            helpLinkUri: "https://posinformatique.github.io/PosInformatique.Moq.Analyzers/docs/Compilation/PosInfoMoq2002.html");
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 

--- a/src/Moq.Analyzers/Analyzers/NoSealedClassAnalyzer.cs
+++ b/src/Moq.Analyzers/Analyzers/NoSealedClassAnalyzer.cs
@@ -45,10 +45,10 @@ namespace PosInformatique.Moq.Analyzers
                 return;
             }
 
-            var moqExpressionAnalyzer = new MoqExpressionAnalyzer(context.SemanticModel);
+            var moqExpressionAnalyzer = new MoqExpressionAnalyzer(moqSymbols, context.SemanticModel);
 
             // Check the expression is a Mock<T> instance creation.
-            var mockedType = moqExpressionAnalyzer.GetMockedType(moqSymbols, objectCreationExpression, out var typeExpression, context.CancellationToken);
+            var mockedType = moqExpressionAnalyzer.GetMockedType(objectCreationExpression, out var typeExpression, context.CancellationToken);
 
             if (mockedType is null)
             {

--- a/src/Moq.Analyzers/Analyzers/SetupMethodMustReturnValueWithStrictBehaviorAnalyzer.cs
+++ b/src/Moq.Analyzers/Analyzers/SetupMethodMustReturnValueWithStrictBehaviorAnalyzer.cs
@@ -22,7 +22,8 @@ namespace PosInformatique.Moq.Analyzers
             "Compilation",
             DiagnosticSeverity.Error,
             isEnabledByDefault: true,
-            description: "The Returns() or ReturnsAsync() methods must be call for Strict mocks.");
+            description: "The Returns() or ReturnsAsync() methods must be call for Strict mocks.",
+            helpLinkUri: "https://posinformatique.github.io/PosInformatique.Moq.Analyzers/docs/Compilation/PosInfoMoq2000.html");
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 

--- a/src/Moq.Analyzers/Analyzers/SetupMethodMustReturnValueWithStrictBehaviorAnalyzer.cs
+++ b/src/Moq.Analyzers/Analyzers/SetupMethodMustReturnValueWithStrictBehaviorAnalyzer.cs
@@ -45,10 +45,10 @@ namespace PosInformatique.Moq.Analyzers
                 return;
             }
 
-            var moqExpressionAnalyzer = new MoqExpressionAnalyzer(context.SemanticModel);
+            var moqExpressionAnalyzer = new MoqExpressionAnalyzer(moqSymbols, context.SemanticModel);
 
             // Check is Setup() method.
-            if (!moqExpressionAnalyzer.IsMockSetupMethod(moqSymbols, invocationExpression, out var localVariableExpression, context.CancellationToken))
+            if (!moqExpressionAnalyzer.IsMockSetupMethod(invocationExpression, out var localVariableExpression, context.CancellationToken))
             {
                 return;
             }
@@ -66,7 +66,7 @@ namespace PosInformatique.Moq.Analyzers
             }
 
             // Check the behavior of the mock instance is Strict.
-            if (!moqExpressionAnalyzer.IsStrictBehavior(moqSymbols, localVariableExpression!, context.CancellationToken))
+            if (!moqExpressionAnalyzer.IsStrictBehavior(localVariableExpression!, context.CancellationToken))
             {
                 return;
             }

--- a/src/Moq.Analyzers/Analyzers/SetupMethodMustReturnValueWithStrictBehaviorAnalyzer.cs
+++ b/src/Moq.Analyzers/Analyzers/SetupMethodMustReturnValueWithStrictBehaviorAnalyzer.cs
@@ -77,7 +77,7 @@ namespace PosInformatique.Moq.Analyzers
 
             foreach (var followingMethod in followingMethods)
             {
-                var methodSymbol = context.SemanticModel.GetSymbolInfo(followingMethod);
+                var methodSymbol = context.SemanticModel.GetSymbolInfo(followingMethod, context.CancellationToken);
 
                 if (methodSymbol.Symbol is null)
                 {

--- a/src/Moq.Analyzers/Analyzers/SetupMustBeUsedOnlyForOverridableMembersAnalyzer.cs
+++ b/src/Moq.Analyzers/Analyzers/SetupMustBeUsedOnlyForOverridableMembersAnalyzer.cs
@@ -48,7 +48,9 @@ namespace PosInformatique.Moq.Analyzers
             var moqExpressionAnalyzer = new MoqExpressionAnalyzer(context.SemanticModel);
 
             // Check is Setup() method.
-            if (!moqExpressionAnalyzer.IsMockSetupMethod(moqSymbols, invocationExpression, out var _, context.CancellationToken))
+            var methodSymbol = context.SemanticModel.GetSymbolInfo(invocationExpression, context.CancellationToken);
+
+            if (!moqSymbols.IsSetupMethod(methodSymbol.Symbol))
             {
                 return;
             }

--- a/src/Moq.Analyzers/Analyzers/SetupMustBeUsedOnlyForOverridableMembersAnalyzer.cs
+++ b/src/Moq.Analyzers/Analyzers/SetupMustBeUsedOnlyForOverridableMembersAnalyzer.cs
@@ -22,7 +22,8 @@ namespace PosInformatique.Moq.Analyzers
             "Compilation",
             DiagnosticSeverity.Error,
             isEnabledByDefault: true,
-            description: "The Setup() method must be used only on overridable members.");
+            description: "The Setup() method must be used only on overridable members.",
+            helpLinkUri: "https://posinformatique.github.io/PosInformatique.Moq.Analyzers/docs/Compilation/PosInfoMoq2001.html");
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 

--- a/src/Moq.Analyzers/Analyzers/SetupMustBeUsedOnlyForOverridableMembersAnalyzer.cs
+++ b/src/Moq.Analyzers/Analyzers/SetupMustBeUsedOnlyForOverridableMembersAnalyzer.cs
@@ -45,7 +45,7 @@ namespace PosInformatique.Moq.Analyzers
                 return;
             }
 
-            var moqExpressionAnalyzer = new MoqExpressionAnalyzer(context.SemanticModel);
+            var moqExpressionAnalyzer = new MoqExpressionAnalyzer(moqSymbols, context.SemanticModel);
 
             // Check is Setup() method.
             var methodSymbol = context.SemanticModel.GetSymbolInfo(invocationExpression, context.CancellationToken);

--- a/src/Moq.Analyzers/Analyzers/SetupProtectedMustBeUsedWithProtectedOrInternalMembersAnalyzer.cs
+++ b/src/Moq.Analyzers/Analyzers/SetupProtectedMustBeUsedWithProtectedOrInternalMembersAnalyzer.cs
@@ -45,10 +45,10 @@ namespace PosInformatique.Moq.Analyzers
                 return;
             }
 
-            var moqExpressionAnalyzer = new MoqExpressionAnalyzer(context.SemanticModel);
+            var moqExpressionAnalyzer = new MoqExpressionAnalyzer(moqSymbols, context.SemanticModel);
 
             // Check is Protected() method.
-            if (!moqExpressionAnalyzer.IsMockSetupMethodProtected(moqSymbols, invocationExpression, out var localVariableExpression, context.CancellationToken))
+            if (!moqExpressionAnalyzer.IsMockSetupMethodProtected(invocationExpression, out var localVariableExpression, context.CancellationToken))
             {
                 return;
             }
@@ -72,7 +72,7 @@ namespace PosInformatique.Moq.Analyzers
             var methodName = literalExpression.Token.ValueText;
 
             // Gets the mocked type
-            var mockedType = moqExpressionAnalyzer.GetMockedType(moqSymbols, localVariableExpression!, context.CancellationToken);
+            var mockedType = moqExpressionAnalyzer.GetMockedType(localVariableExpression!, context.CancellationToken);
 
             if (mockedType is null)
             {

--- a/src/Moq.Analyzers/Analyzers/SetupProtectedMustBeUsedWithProtectedOrInternalMembersAnalyzer.cs
+++ b/src/Moq.Analyzers/Analyzers/SetupProtectedMustBeUsedWithProtectedOrInternalMembersAnalyzer.cs
@@ -22,7 +22,8 @@ namespace PosInformatique.Moq.Analyzers
             "Compilation",
             DiagnosticSeverity.Error,
             isEnabledByDefault: true,
-            description: "The Protected().Setup() method must be use with overridable protected or internal methods.");
+            description: "The Protected().Setup() method must be use with overridable protected or internal methods.",
+            helpLinkUri: "https://posinformatique.github.io/PosInformatique.Moq.Analyzers/docs/Compilation/PosInfoMoq2006.html");
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 

--- a/src/Moq.Analyzers/Analyzers/VerifyAllShouldBeCalledAnalyzer.cs
+++ b/src/Moq.Analyzers/Analyzers/VerifyAllShouldBeCalledAnalyzer.cs
@@ -45,9 +45,9 @@ namespace PosInformatique.Moq.Analyzers
                 return;
             }
 
-            var moqExpressionAnalyzer = new MoqExpressionAnalyzer(context.SemanticModel);
+            var moqExpressionAnalyzer = new MoqExpressionAnalyzer(moqSymbols, context.SemanticModel);
 
-            if (!moqExpressionAnalyzer.IsMockCreation(moqSymbols, objectCreation, context.CancellationToken))
+            if (!moqExpressionAnalyzer.IsMockCreation(objectCreation, context.CancellationToken))
             {
                 return;
             }

--- a/src/Moq.Analyzers/Analyzers/VerifyAllShouldBeCalledAnalyzer.cs
+++ b/src/Moq.Analyzers/Analyzers/VerifyAllShouldBeCalledAnalyzer.cs
@@ -22,7 +22,8 @@ namespace PosInformatique.Moq.Analyzers
             "Design",
             DiagnosticSeverity.Warning,
             isEnabledByDefault: true,
-            description: "VerifyAll() or VerifyAll() methods should be called at the end of the unit test method.");
+            description: "VerifyAll() or VerifyAll() methods should be called at the end of the unit test method.",
+            helpLinkUri: "https://posinformatique.github.io/PosInformatique.Moq.Analyzers/docs/Design/PosInfoMoq1000.html");
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 

--- a/src/Moq.Analyzers/Analyzers/VerifyMustBeUsedOnlyForOverridableMembersAnalyzer.cs
+++ b/src/Moq.Analyzers/Analyzers/VerifyMustBeUsedOnlyForOverridableMembersAnalyzer.cs
@@ -22,7 +22,8 @@ namespace PosInformatique.Moq.Analyzers
             "Compilation",
             DiagnosticSeverity.Error,
             isEnabledByDefault: true,
-            description: "The Verify() method must be used only on overridable members.");
+            description: "The Verify() method must be used only on overridable members.",
+            helpLinkUri: "https://posinformatique.github.io/PosInformatique.Moq.Analyzers/docs/Compilation/PosInfoMoq2008.html");
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 

--- a/src/Moq.Analyzers/Analyzers/VerifyMustBeUsedOnlyForOverridableMembersAnalyzer.cs
+++ b/src/Moq.Analyzers/Analyzers/VerifyMustBeUsedOnlyForOverridableMembersAnalyzer.cs
@@ -1,5 +1,5 @@
 ﻿//-----------------------------------------------------------------------
-// <copyright file="SetupMustBeUsedOnlyForOverridableMembersAnalyzer.cs" company="P.O.S Informatique">
+// <copyright file="VerifyMustBeUsedOnlyForOverridableMembersAnalyzer.cs" company="P.O.S Informatique">
 //     Copyright (c) P.O.S Informatique. All rights reserved.
 // </copyright>
 //-----------------------------------------------------------------------
@@ -13,16 +13,16 @@ namespace PosInformatique.Moq.Analyzers
     using Microsoft.CodeAnalysis.Diagnostics;
 
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public class SetupMustBeUsedOnlyForOverridableMembersAnalyzer : DiagnosticAnalyzer
+    public class VerifyMustBeUsedOnlyForOverridableMembersAnalyzer : DiagnosticAnalyzer
     {
         private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
-            "PosInfoMoq2001",
-            "The Setup() method must be used only on overridable members",
-            "The Setup() method must be used only on overridable members",
+            "PosInfoMoq2008",
+            "The Verify() method must be used only on overridable members",
+            "The Verify() method must be used only on overridable members",
             "Compilation",
             DiagnosticSeverity.Error,
             isEnabledByDefault: true,
-            description: "The Setup() method must be used only on overridable members.");
+            description: "The Verify() method must be used only on overridable members.");
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 
@@ -50,7 +50,7 @@ namespace PosInformatique.Moq.Analyzers
             // Check is Setup() method.
             var methodSymbol = context.SemanticModel.GetSymbolInfo(invocationExpression, context.CancellationToken);
 
-            if (!moqSymbols.IsSetupMethod(methodSymbol.Symbol))
+            if (!moqSymbols.IsVerifyMethod(methodSymbol.Symbol))
             {
                 return;
             }

--- a/src/Moq.Analyzers/Analyzers/VerifyShouldBeCalledAnalyzer.cs
+++ b/src/Moq.Analyzers/Analyzers/VerifyShouldBeCalledAnalyzer.cs
@@ -1,5 +1,5 @@
 ﻿//-----------------------------------------------------------------------
-// <copyright file="VerifyAllShouldBeCalledAnalyzer.cs" company="P.O.S Informatique">
+// <copyright file="VerifyShouldBeCalledAnalyzer.cs" company="P.O.S Informatique">
 //     Copyright (c) P.O.S Informatique. All rights reserved.
 // </copyright>
 //-----------------------------------------------------------------------
@@ -13,7 +13,7 @@ namespace PosInformatique.Moq.Analyzers
     using Microsoft.CodeAnalysis.Diagnostics;
 
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public class VerifyAllShouldBeCalledAnalyzer : DiagnosticAnalyzer
+    public class VerifyShouldBeCalledAnalyzer : DiagnosticAnalyzer
     {
         private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
             "PosInfoMoq1000",

--- a/src/Moq.Analyzers/Moq.Analyzers.csproj
+++ b/src/Moq.Analyzers/Moq.Analyzers.csproj
@@ -17,6 +17,15 @@
     <PackageProjectUrl>https://github.com/PosInformatique/PosInformatique.Moq.Analyzers</PackageProjectUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>
+      1.6.0
+      - Add new rules:
+        - PosInfoMoq2007: The As&lt;T&gt;() method can be used only with interfaces.
+        - PosInfoMoq2008: The Verify() method must be used only on overridable members
+      - Add the support of static methods VerifyAll() and Verify() for the PosInfoMoq2000 rule.
+      - Various optimizations to increase speed of analysis.
+      - Various optimizations to reduce memory usage.
+      - Add hyperlink to the documentation of the r
+      
       1.5.0
       - Add new rules:
         - PosInfoMoq2004: Check that constructor arguments can not be passed to a mocked interface.

--- a/src/Moq.Analyzers/MoqExpressionAnalyzer.cs
+++ b/src/Moq.Analyzers/MoqExpressionAnalyzer.cs
@@ -295,7 +295,7 @@ namespace PosInformatique.Moq.Analyzers
         {
             memberIdentifierName = null;
 
-            var members = this.ExtractSetupMembers(invocationExpression, cancellationToken);
+            var members = this.ExtractChainedMembersInvocationFromLambdaExpression(invocationExpression, cancellationToken);
 
             var member = members.FirstOrDefault();
 
@@ -314,9 +314,10 @@ namespace PosInformatique.Moq.Analyzers
             return methodSymbol;
         }
 
-        public IReadOnlyList<SetupMember> ExtractSetupMembers(InvocationExpressionSyntax invocationExpression, CancellationToken cancellationToken)
+        public IReadOnlyList<SetupMember> ExtractChainedMembersInvocationFromLambdaExpression(InvocationExpressionSyntax invocationExpression, CancellationToken cancellationToken)
         {
-            if (invocationExpression.ArgumentList.Arguments.Count != 1)
+            // Check the invocation expression is Setup(m => xxxxx) / Verify(m => xxxx) expression which contains a lambda expression.
+            if (invocationExpression.ArgumentList.Arguments.Count == 0)
             {
                 return Array.Empty<SetupMember>();
             }
@@ -326,6 +327,7 @@ namespace PosInformatique.Moq.Analyzers
                 return Array.Empty<SetupMember>();
             }
 
+            // Extract inside the body expression the chained members.
             ExpressionSyntax bodyExpression;
 
             if (lambdaExpression.Body is InvocationExpressionSyntax invocationMemberExpression)

--- a/src/Moq.Analyzers/MoqExpressionAnalyzer.cs
+++ b/src/Moq.Analyzers/MoqExpressionAnalyzer.cs
@@ -388,6 +388,37 @@ namespace PosInformatique.Moq.Analyzers
             return methodSymbol;
         }
 
+        public ITypeSymbol? ExtractAsMethodType(MoqSymbols moqSymbols, InvocationExpressionSyntax invocationExpression, out TypeSyntax? typeSyntax, CancellationToken cancellationToken)
+        {
+            typeSyntax = null;
+
+            if (invocationExpression.Expression is not MemberAccessExpressionSyntax memberAccessExpression)
+            {
+                return null;
+            }
+
+            if (memberAccessExpression.Name is not GenericNameSyntax genericName)
+            {
+                return null;
+            }
+
+            var symbol = this.semanticModel.GetSymbolInfo(memberAccessExpression.Name, cancellationToken);
+
+            if (symbol.Symbol is not IMethodSymbol methodSymbol)
+            {
+                return null;
+            }
+
+            if (!moqSymbols.IsAsMethod(methodSymbol))
+            {
+                return null;
+            }
+
+            typeSyntax = genericName.TypeArgumentList.Arguments[0];
+
+            return methodSymbol.TypeArguments[0];
+        }
+
         private static ObjectCreationExpressionSyntax? FindMockCreation(BlockSyntax block, string variableName)
         {
             foreach (var statement in block.Statements.OfType<LocalDeclarationStatementSyntax>())

--- a/src/Moq.Analyzers/MoqSymbols.cs
+++ b/src/Moq.Analyzers/MoqSymbols.cs
@@ -43,7 +43,7 @@ namespace PosInformatique.Moq.Analyzers
             this.mockBehaviorStrictField = new Lazy<ISymbol>(() => this.mockBehaviorEnum.Value.GetMembers("Strict").First());
             this.setupProtectedMethods = new Lazy<IReadOnlyList<IMethodSymbol>>(() => compilation.GetTypeByMetadataName("Moq.Protected.IProtectedMock`1")!.GetMembers("Setup").OfType<IMethodSymbol>().ToArray());
             this.asMethod = new Lazy<ISymbol>(() => mockGenericClass.GetMembers("As").Single());
-            this.verifyMethods = new Lazy<IReadOnlyList<IMethodSymbol>>(() => mockGenericClass.GetMembers("Verify").OfType<IMethodSymbol>().ToArray());
+            this.verifyMethods = new Lazy<IReadOnlyList<IMethodSymbol>>(() => mockGenericClass.GetMembers("Verify").Concat(mockGenericClass.BaseType!.GetMembers("Verify")).Where(m => !m.IsStatic).OfType<IMethodSymbol>().ToArray());
 
             this.staticVerifyMethod = new Lazy<IMethodSymbol>(() => mockGenericClass.BaseType!.GetMembers("Verify").Where(m => m.IsStatic).OfType<IMethodSymbol>().Single());
             this.staticVerifyAllMethod = new Lazy<IMethodSymbol>(() => mockGenericClass.BaseType!.GetMembers("VerifyAll").Where(m => m.IsStatic).OfType<IMethodSymbol>().Single());

--- a/src/Moq.Analyzers/MoqSymbols.cs
+++ b/src/Moq.Analyzers/MoqSymbols.cs
@@ -47,7 +47,7 @@ namespace PosInformatique.Moq.Analyzers
 
             this.staticVerifyMethod = new Lazy<IMethodSymbol>(() => mockGenericClass.BaseType!.GetMembers("Verify").Where(m => m.IsStatic).OfType<IMethodSymbol>().Single());
             this.staticVerifyAllMethod = new Lazy<IMethodSymbol>(() => mockGenericClass.BaseType!.GetMembers("VerifyAll").Where(m => m.IsStatic).OfType<IMethodSymbol>().Single());
-            this.verifyAllMethod = new Lazy<IMethodSymbol>(() => mockGenericClass.GetMembers("VerifyAll").OfType<IMethodSymbol>().Single());
+            this.verifyAllMethod = new Lazy<IMethodSymbol>(() => mockGenericClass.BaseType!.GetMembers("VerifyAll").Where(m => !m.IsStatic).OfType<IMethodSymbol>().Single());
         }
 
         public static MoqSymbols? FromCompilation(Compilation compilation)

--- a/src/Moq.Analyzers/MoqSymbols.cs
+++ b/src/Moq.Analyzers/MoqSymbols.cs
@@ -19,6 +19,8 @@ namespace PosInformatique.Moq.Analyzers
 
         private readonly IReadOnlyList<IMethodSymbol> setupProtectedMethods;
 
+        private readonly IReadOnlyList<IMethodSymbol> verifyMethods;
+
         private readonly ISymbol mockBehaviorStrictField;
 
         private readonly ISymbol isAnyTypeClass;
@@ -35,6 +37,7 @@ namespace PosInformatique.Moq.Analyzers
             this.mockBehaviorStrictField = mockBehaviorEnum.GetMembers("Strict").First();
             this.setupProtectedMethods = protectedMockInterface.GetMembers("Setup").OfType<IMethodSymbol>().ToArray();
             this.asMethod = mockClass.GetMembers("As").Single();
+            this.verifyMethods = mockClass.GetMembers("Verify").OfType<IMethodSymbol>().ToArray();
         }
 
         public static MoqSymbols? FromCompilation(Compilation compilation)
@@ -133,6 +136,36 @@ namespace PosInformatique.Moq.Analyzers
             }
 
             return false;
+        }
+
+        public bool IsVerifyMethod(ISymbol? symbol)
+        {
+            if (symbol is null)
+            {
+                return false;
+            }
+
+            var originalDefinition = symbol.OriginalDefinition;
+
+            foreach (var verifyMethod in this.verifyMethods)
+            {
+                if (SymbolEqualityComparer.Default.Equals(originalDefinition, verifyMethod))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        public bool IsVerifyAllMethod(ISymbol symbol)
+        {
+            if (symbol.Name != "VerifyAll")
+            {
+                return false;
+            }
+
+            return true;
         }
 
         public bool IsCallback(ISymbol? symbol)

--- a/src/Moq.Analyzers/MoqSymbols.cs
+++ b/src/Moq.Analyzers/MoqSymbols.cs
@@ -6,6 +6,7 @@
 
 namespace PosInformatique.Moq.Analyzers
 {
+    using System;
     using Microsoft.CodeAnalysis;
 
     internal sealed class MoqSymbols
@@ -22,6 +23,8 @@ namespace PosInformatique.Moq.Analyzers
 
         private readonly ISymbol isAnyTypeClass;
 
+        private readonly ISymbol asMethod;
+
         private MoqSymbols(INamedTypeSymbol mockClass, INamedTypeSymbol mockBehaviorEnum, ISymbol isAnyTypeClass, INamedTypeSymbol protectedMockInterface)
         {
             this.mockClass = mockClass;
@@ -31,6 +34,7 @@ namespace PosInformatique.Moq.Analyzers
             this.setupMethods = mockClass.GetMembers("Setup").OfType<IMethodSymbol>().ToArray();
             this.mockBehaviorStrictField = mockBehaviorEnum.GetMembers("Strict").First();
             this.setupProtectedMethods = protectedMockInterface.GetMembers("Setup").OfType<IMethodSymbol>().ToArray();
+            this.asMethod = mockClass.GetMembers("As").Single();
         }
 
         public static MoqSymbols? FromCompilation(Compilation compilation)
@@ -274,6 +278,16 @@ namespace PosInformatique.Moq.Analyzers
             }
 
             return false;
+        }
+
+        public bool IsAsMethod(IMethodSymbol method)
+        {
+            if (!SymbolEqualityComparer.Default.Equals(method.OriginalDefinition, this.asMethod))
+            {
+                return false;
+            }
+
+            return true;
         }
     }
 }

--- a/tests/Moq.Analyzers.Sandbox/Sandbox.cs
+++ b/tests/Moq.Analyzers.Sandbox/Sandbox.cs
@@ -6,6 +6,8 @@
 
 namespace PosInformatique.Moq.Analyzers.Sandbox
 {
+    using global::Moq;
+
     public class Sandbox
     {
         public void TestCodeHere()

--- a/tests/Moq.Analyzers.Tests/Analyzers/AsMustBeUsedWithInterfaceAnalyzerTest.cs
+++ b/tests/Moq.Analyzers.Tests/Analyzers/AsMustBeUsedWithInterfaceAnalyzerTest.cs
@@ -1,0 +1,146 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="AsMustBeUsedWithInterfaceAnalyzerTest.cs" company="P.O.S Informatique">
+//     Copyright (c) P.O.S Informatique. All rights reserved.
+// </copyright>
+//-----------------------------------------------------------------------
+
+namespace PosInformatique.Moq.Analyzers.Tests
+{
+    using System.Threading.Tasks;
+    using Xunit;
+    using Verify = Microsoft.CodeAnalysis.CSharp.Testing.CSharpAnalyzerVerifier<
+        AsMustBeUsedWithInterfaceAnalyzer,
+        Microsoft.CodeAnalysis.Testing.DefaultVerifier>;
+
+    public class AsMustBeUsedWithInterfaceAnalyzerTest
+    {
+        [Fact]
+        public async Task AsMethod_WithInterface()
+        {
+            var source = @"
+                namespace ConsoleApplication1
+                {
+                    using Moq;
+
+                    public class TestClass
+                    {
+                        public void TestMethod()
+                        {
+                            var mock1 = new Mock<C>();
+                            mock1.As<I>();
+                        }
+                    }
+
+                    public class C
+                    {
+                    }
+
+                    public interface I
+                    {
+                    }
+                }" + MoqLibrary.Code;
+
+            await Verify.VerifyAnalyzerAsync(source);
+        }
+
+        [Fact]
+        public async Task AsMethod_WithClass()
+        {
+            var source = @"
+                namespace ConsoleApplication1
+                {
+                    using Moq;
+
+                    public class TestClass
+                    {
+                        public void TestMethod()
+                        {
+                            var mock1 = new Mock<C>();
+                            mock1.As<[|C2|]>();
+                        }
+                    }
+
+                    public class C
+                    {
+                    }
+
+                    public class C2
+                    {
+                    }
+                }" + MoqLibrary.Code;
+
+            await Verify.VerifyAnalyzerAsync(source);
+        }
+
+        [Fact]
+        public async Task NoAsMethod()
+        {
+            var source = @"
+                namespace ConsoleApplication1
+                {
+                    using Moq;
+
+                    public class TestClass
+                    {
+
+                        public void TestMethod()
+                        {
+                            var mock1 = new Mock<C>();
+                            mock1.Setup(m => m.Method());
+
+                            var action = new System.Action(() => { });
+                            action();   // Ignored by the ExtractAsMethodType() method because not a MemberAccessExpressionSyntax.
+
+                            var otherClass = new OtherClass();
+                            otherClass.GenericMethodNotAs<C>(); // Ignored by the ExtractAsMethodType() method because it not As<T>() symbol.
+                        }
+                    }
+
+                    public class C
+                    {
+                        public virtual void Method() { }
+                    }
+
+                    public class OtherClass
+                    {
+                        public void GenericMethodNotAs<T>() { }
+                    }
+                }" + MoqLibrary.Code;
+
+            await Verify.VerifyAnalyzerAsync(source);
+        }
+
+        [Fact]
+        public async Task NoMoqLibrary()
+        {
+            var source = @"
+                namespace ConsoleApplication1
+                {
+                    using OtherNamespace;
+
+                    public class TestClass
+                    {
+                        public void TestMethod()
+                        {
+                            var mock1 = new Mock<I>();
+                            mock1.As<I>();
+                        }
+                    }
+
+                    public interface I
+                    {
+                    }
+                }
+
+                namespace OtherNamespace
+                {
+                    public class Mock<T>
+                    {
+                        public void As<TInterface>() { }
+                    }
+                }";
+
+            await Verify.VerifyAnalyzerAsync(source);
+        }
+    }
+}

--- a/tests/Moq.Analyzers.Tests/Analyzers/CallBackDelegateMustMatchMockedMethodAnalyzerTest.cs
+++ b/tests/Moq.Analyzers.Tests/Analyzers/CallBackDelegateMustMatchMockedMethodAnalyzerTest.cs
@@ -70,6 +70,12 @@ namespace PosInformatique.Moq.Analyzers.Tests
                                 .Callback()
                                 .Throws()
                                 .Callback();
+
+                            // Special case add a Verify() method inside the Callback() method.
+                            var innerMock = new Mock<I>();
+
+                            mock1.Setup(m => m.TestMethod())
+                                .Callback(() => { innerMock.Verify(im => im.TestMethod(""a"")); });
                         }
                     }
 

--- a/tests/Moq.Analyzers.Tests/Analyzers/VerifyAllShouldBeCalledAnalyzerTest.cs
+++ b/tests/Moq.Analyzers.Tests/Analyzers/VerifyAllShouldBeCalledAnalyzerTest.cs
@@ -32,6 +32,8 @@ namespace PosInformatique.Moq.Analyzers.Tests
                             o.ToString();
 
                             var mock2 = new Mock<I>();
+                            var mock3 = new Mock<I>();
+                            var mock4 = new Mock<I>();
 
                             new Mock<I>();  // No variable (ignored)
 
@@ -40,12 +42,15 @@ namespace PosInformatique.Moq.Analyzers.Tests
                             mock1.Property = 1234;  // Property access are ignored.
 
                             mock1.VerifyAll();
-                            mock2.Verify(1, 2);
+                            mock2.Verify();
+                            mock3.Verify(m => m.Method());
+                            mock4.Verify(m => m.Method(), ""Foobar"");
                         }
                     }
 
                     public interface I
                     {
+                        void Method();
                     }
                 }
                 " + MoqLibrary.Code;

--- a/tests/Moq.Analyzers.Tests/Analyzers/VerifyMustBeUsedOnlyForOverridableMembersAnalyzerTest.cs
+++ b/tests/Moq.Analyzers.Tests/Analyzers/VerifyMustBeUsedOnlyForOverridableMembersAnalyzerTest.cs
@@ -1,0 +1,286 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="VerifyMustBeUsedOnlyForOverridableMembersAnalyzerTest.cs" company="P.O.S Informatique">
+//     Copyright (c) P.O.S Informatique. All rights reserved.
+// </copyright>
+//-----------------------------------------------------------------------
+
+namespace PosInformatique.Moq.Analyzers.Tests
+{
+    using System.Threading.Tasks;
+    using Xunit;
+    using Verify = Microsoft.CodeAnalysis.CSharp.Testing.CSharpAnalyzerVerifier<
+        VerifyMustBeUsedOnlyForOverridableMembersAnalyzer,
+        Microsoft.CodeAnalysis.Testing.DefaultVerifier>;
+
+    public class VerifyMustBeUsedOnlyForOverridableMembersAnalyzerTest
+    {
+        [Theory]
+        [InlineData("")]
+        [InlineData(", \"The message\"")]
+        public async Task Overridable_NoDiagnosticReported(string secondArgument)
+        {
+            var source = @"
+                namespace ConsoleApplication1
+                {
+                    using Moq;
+                    using System;
+
+                    public class TestClass
+                    {
+                        public void TestMethod()
+                        {
+                            var mock1 = new Mock<I>();
+                            mock1.Verify(i => i.TestMethod()" + secondArgument + @");
+                            mock1.Verify(i => i.TestProperty" + secondArgument + @");
+                            mock1.Verify(i => i.InnerObject.VirtualMethod()" + secondArgument + @");
+                            mock1.Verify(i => i.InnerObject.VirtualProperty" + secondArgument + @");
+                            mock1.Verify(i => i.InnerObject.AbstractMethod()" + secondArgument + @");
+                            mock1.Verify(i => i.InnerObject.AbstractProperty" + secondArgument + @");
+
+                            var mock2 = new Mock<StandardClass>();
+                            mock2.Verify(i => i.VirtualMethod()" + secondArgument + @");
+                            mock2.Verify(i => i.VirtualProperty" + secondArgument + @");
+                            mock2.Verify(i => i.InnerObject.VirtualMethod()" + secondArgument + @");
+                            mock2.Verify(i => i.InnerObject.VirtualProperty" + secondArgument + @");
+                            mock2.Verify(i => i.InnerObject.AbstractMethod()" + secondArgument + @");
+                            mock2.Verify(i => i.InnerObject.AbstractProperty" + secondArgument + @");
+
+                            var mock3 = new Mock<AbstractClass>();
+                            mock3.Verify(i => i.VirtualMethod()" + secondArgument + @");
+                            mock3.Verify(i => i.VirtualProperty" + secondArgument + @");
+                            mock3.Verify(i => i.AbstractMethod()" + secondArgument + @");
+                            mock3.Verify(i => i.AbstractProperty" + secondArgument + @");
+                            mock3.Verify(i => i.InnerObject.VirtualMethod()" + secondArgument + @");
+                            mock3.Verify(i => i.InnerObject.VirtualProperty" + secondArgument + @");
+                            mock3.Verify(i => i.InnerObject.AbstractMethod()" + secondArgument + @");
+                            mock3.Verify(i => i.InnerObject.AbstractProperty" + secondArgument + @");
+
+                            var mock4 = new Mock<InheritedFromAbstractClass>();
+                            mock4.Verify(i => i.VirtualMethod()" + secondArgument + @");
+                            mock4.Verify(i => i.VirtualProperty" + secondArgument + @");
+                            mock4.Verify(i => i.AbstractMethod()" + secondArgument + @");
+                            mock4.Verify(i => i.AbstractProperty" + secondArgument + @");
+                            mock4.Verify(i => i.InnerObject.VirtualMethod()" + secondArgument + @");
+                            mock4.Verify(i => i.InnerObject.VirtualProperty" + secondArgument + @");
+                            mock4.Verify(i => i.InnerObject.AbstractMethod()" + secondArgument + @");
+                            mock4.Verify(i => i.InnerObject.AbstractProperty" + secondArgument + @");
+
+                            var mock5 = new Mock<InheritedFromAbstractClassDontOverrideVirtual>();
+                            mock5.Verify(i => i.VirtualMethod()" + secondArgument + @");
+                            mock5.Verify(i => i.VirtualProperty" + secondArgument + @");
+                            mock5.Verify(i => i.AbstractMethod()" + secondArgument + @");
+                            mock5.Verify(i => i.AbstractProperty" + secondArgument + @");
+                            mock5.Verify(i => i.InnerObject.VirtualMethod()" + secondArgument + @");
+                            mock5.Verify(i => i.InnerObject.VirtualProperty" + secondArgument + @");
+                            mock5.Verify(i => i.InnerObject.AbstractMethod()" + secondArgument + @");
+                            mock5.Verify(i => i.InnerObject.AbstractProperty" + secondArgument + @");
+                        }
+                    }
+
+                    public interface I
+                    {
+                        int TestMethod();
+
+                        string TestProperty { get; }
+
+                        InnerObject InnerObject { get; }
+                    }
+
+                    public class StandardClass
+                    {
+                        public virtual void VirtualMethod() { }
+
+                        public virtual string VirtualProperty => null;
+
+                        public virtual InnerObject InnerObject { get => null; }
+                    }
+
+                    public abstract class AbstractClass
+                    {
+                        public virtual void VirtualMethod() { }
+
+                        public virtual string VirtualProperty => null;
+
+                        public abstract void AbstractMethod();
+
+                        public abstract string AbstractProperty { get; }
+
+                        public abstract InnerObject InnerObject { get; }
+                    }
+
+                    public class InheritedFromAbstractClass : AbstractClass
+                    {
+                        public override void AbstractMethod() { }
+
+                        public override string AbstractProperty => null;
+
+                        public override void VirtualMethod() { }
+
+                        public override string VirtualProperty => null;
+
+                        public override InnerObject InnerObject => null;
+                    }
+
+                    public class InheritedFromAbstractClassDontOverrideVirtual : AbstractClass
+                    {
+                        public override void AbstractMethod() { }
+
+                        public override string AbstractProperty => null;
+
+                        public override InnerObject InnerObject => null;
+                    }
+
+                    public abstract class InnerObject
+                    {
+                        public virtual void VirtualMethod() { }
+
+                        public virtual string VirtualProperty => null;
+
+                        public abstract void AbstractMethod();
+
+                        public abstract string AbstractProperty { get; }
+                    }
+                }
+                " + MoqLibrary.Code;
+
+            await Verify.VerifyAnalyzerAsync(source);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData(", \"The message\"")]
+        public async Task NoOverridable_DiagnosticReported(string secondArgument)
+        {
+            var source = @"
+                namespace ConsoleApplication1
+                {
+                    using Moq;
+                    using System;
+
+                    public class TestClass
+                    {
+                        public void TestMethod()
+                        {
+                            var mock1 = new Mock<StandardClass>();
+                            mock1.Verify(i => i.[|Method|]()" + secondArgument + @");
+                            mock1.Verify(i => i.[|Property|]" + secondArgument + @");
+                            mock1.Verify(i => i.[|InnerObject|].VirtualMethod()" + secondArgument + @");
+                            mock1.Verify(i => i.[|InnerObject|].VirtualProperty" + secondArgument + @");
+                            mock1.Verify(i => i.AbstractInnerObject.[|Method|]()" + secondArgument + @");
+                            mock1.Verify(i => i.AbstractInnerObject.[|Property|]" + secondArgument + @");
+                            mock1.Verify(i => i.[|SealedInnerObject|].VirtualMethod()" + secondArgument + @");
+                            mock1.Verify(i => i.[|SealedInnerObject|].VirtualProperty" + secondArgument + @");
+
+                            var mock2 = new Mock<StandardClass>();
+                            mock2.Verify(i => StandardClass.[|StaticMethod|]()" + secondArgument + @");
+
+                            var mock3 = new Mock<AbstractClass>();
+                            mock3.Verify(i => i.[|Method|]()" + secondArgument + @");
+                            mock3.Verify(i => i.[|Property|]" + secondArgument + @");
+
+                            var mock4 = new Mock<I>();
+                            mock4.Verify(i => i.[|ExtensionMethod|]()" + secondArgument + @");
+                        }
+                    }
+
+                    public class StandardClass
+                    {
+                        public void Method() { }
+
+                        public string Property => null;
+
+                        public static void StaticMethod() { }
+
+                        public InnerObject InnerObject => null;
+
+                        public AbstractInnerObject AbstractInnerObject => null;
+
+                        public SealedInnerObject SealedInnerObject => null;
+                    }
+
+                    public abstract class AbstractClass
+                    {
+                        public void Method() { }
+
+                        public string Property => null;
+                    }
+
+                    public interface I
+                    {
+                        int TestMethod();
+                    }
+
+                    public static class ExtensionsClass
+                    {
+                        public static void ExtensionMethod(this I _) { }
+                    }
+
+                    public class InnerObject
+                    {
+                        public virtual void VirtualMethod() { }
+
+                        public virtual string VirtualProperty => null;
+                    }
+
+                    public abstract class AbstractInnerObject
+                    {
+                        public void Method() { }
+
+                        public string Property { get => null; }
+
+                        public abstract void VirtualMethod();
+
+                        public abstract string VirtualProperty { get; }
+                    }
+
+                    public sealed class SealedInnerObject : AbstractInnerObject
+                    {
+                        public override void VirtualMethod() { }
+
+                        public override string VirtualProperty => null;
+                    }
+                }
+                " + MoqLibrary.Code;
+
+            await Verify.VerifyAnalyzerAsync(source);
+        }
+
+        [Fact]
+        public async Task NoMoqLibrary()
+        {
+            var source = @"
+                namespace ConsoleApplication1
+                {
+                    using OtherNamespace;
+
+                    public class TestClass
+                    {
+                        public void TestMethod()
+                        {
+                            var mock1 = new Mock<I>(MockBehavior.Strict);
+                            mock1.Verify(i => i.Method());
+                        }
+                    }
+
+                    public interface I
+                    {
+                        void Method();
+                    }
+                }
+
+                namespace OtherNamespace
+                {
+                    public class Mock<T>
+                    {
+                        public Mock(MockBehavior _) { }
+
+                        public void Verify(System.Action<T> _) { }
+                    }
+
+                    public enum MockBehavior { Strict, Loose }
+                }";
+
+            await Verify.VerifyAnalyzerAsync(source);
+        }
+    }
+}

--- a/tests/Moq.Analyzers.Tests/Analyzers/VerifyShouldBeCalledAnalyzerTest.cs
+++ b/tests/Moq.Analyzers.Tests/Analyzers/VerifyShouldBeCalledAnalyzerTest.cs
@@ -34,6 +34,12 @@ namespace PosInformatique.Moq.Analyzers.Tests
                             var mock2 = new Mock<I>();
                             var mock3 = new Mock<I>();
                             var mock4 = new Mock<I>();
+                            var mock5 = new Mock<I>();
+                            var mock6 = new Mock<I>();
+                            var mock7 = new Mock<I>();
+                            var mock8 = new Mock<I>();
+                            var mock9 = new Mock<I>();
+                            var mock10 = new Mock<I>();
 
                             new Mock<I>();  // No variable (ignored)
 
@@ -45,7 +51,13 @@ namespace PosInformatique.Moq.Analyzers.Tests
                             mock2.Verify();
                             mock3.Verify(m => m.Method());
                             mock4.Verify(m => m.Method(), ""Foobar"");
-                        }
+
+                            Mock.VerifyAll(mock5, mock6);
+                            Mock.Verify(mock7, mock8);
+
+                            Mock<I>.VerifyAll(mock9);
+                            Mock<I>.Verify(mock10);
+                       }
                     }
 
                     public interface I

--- a/tests/Moq.Analyzers.Tests/Analyzers/VerifyShouldBeCalledAnalyzerTest.cs
+++ b/tests/Moq.Analyzers.Tests/Analyzers/VerifyShouldBeCalledAnalyzerTest.cs
@@ -1,5 +1,5 @@
 ﻿//-----------------------------------------------------------------------
-// <copyright file="VerifyAllShouldBeCalledAnalyzerTest.cs" company="P.O.S Informatique">
+// <copyright file="VerifyShouldBeCalledAnalyzerTest.cs" company="P.O.S Informatique">
 //     Copyright (c) P.O.S Informatique. All rights reserved.
 // </copyright>
 //-----------------------------------------------------------------------
@@ -9,10 +9,10 @@ namespace PosInformatique.Moq.Analyzers.Tests
     using System.Threading.Tasks;
     using Xunit;
     using Verify = Microsoft.CodeAnalysis.CSharp.Testing.CSharpAnalyzerVerifier<
-        VerifyAllShouldBeCalledAnalyzer,
+        VerifyShouldBeCalledAnalyzer,
         Microsoft.CodeAnalysis.Testing.DefaultVerifier>;
 
-    public class VerifyAllShouldBeCalledAnalyzerTest
+    public class VerifyShouldBeCalledAnalyzerTest
     {
         [Fact]
         public async Task Verify_Called()

--- a/tests/Moq.Analyzers.Tests/MoqLibrary.cs
+++ b/tests/Moq.Analyzers.Tests/MoqLibrary.cs
@@ -14,7 +14,7 @@ namespace PosInformatique.Moq.Analyzers.Tests
                 using System;
                 using System.Linq.Expressions;
 
-                public class Mock<T>
+                public class Mock<T> : Mock
                 {
                     public Mock(MockBehavior _ = MockBehavior.Loose, params object[] args) { }
 
@@ -39,6 +39,13 @@ namespace PosInformatique.Moq.Analyzers.Tests
                     public void Verify<TResult>(Expression<Func<T, TResult>> _, string failedMessage) { }
 
                     public object Property { get; set; }
+                }
+
+                public class Mock
+                {
+                    public static void Verify(params Mock[] mocks) { }
+
+                    public static void VerifyAll(params Mock[] mocks) { }
                 }
 
                 public enum MockBehavior { Strict, Loose }

--- a/tests/Moq.Analyzers.Tests/MoqLibrary.cs
+++ b/tests/Moq.Analyzers.Tests/MoqLibrary.cs
@@ -26,8 +26,6 @@ namespace PosInformatique.Moq.Analyzers.Tests
 
                     public ISetup<TResult> Setup<TResult>(Func<T, TResult> func) { return default; }
 
-                    public void VerifyAll() { }
-
                     public void Verify() { }
 
                     public void Verify(Expression<Action<T>> _) { }
@@ -44,6 +42,8 @@ namespace PosInformatique.Moq.Analyzers.Tests
                 public class Mock
                 {
                     public static void Verify(params Mock[] mocks) { }
+
+                    public void VerifyAll() { }
 
                     public static void VerifyAll(params Mock[] mocks) { }
                 }

--- a/tests/Moq.Analyzers.Tests/MoqLibrary.cs
+++ b/tests/Moq.Analyzers.Tests/MoqLibrary.cs
@@ -12,6 +12,7 @@ namespace PosInformatique.Moq.Analyzers.Tests
             namespace Moq
             {
                 using System;
+                using System.Linq.Expressions;
 
                 public class Mock<T>
                 {
@@ -29,7 +30,13 @@ namespace PosInformatique.Moq.Analyzers.Tests
 
                     public void Verify() { }
 
-                    public void Verify(int a, int b) { }
+                    public void Verify(Expression<Action<T>> _) { }
+
+                    public void Verify<TResult>(Expression<Func<T, TResult>> _) { }
+
+                    public void Verify(Expression<Action<T>> _, string failedMessage) { }
+
+                    public void Verify<TResult>(Expression<Func<T, TResult>> _, string failedMessage) { }
 
                     public object Property { get; set; }
                 }

--- a/tests/Moq.Analyzers.Tests/MoqLibrary.cs
+++ b/tests/Moq.Analyzers.Tests/MoqLibrary.cs
@@ -26,8 +26,6 @@ namespace PosInformatique.Moq.Analyzers.Tests
 
                     public ISetup<TResult> Setup<TResult>(Func<T, TResult> func) { return default; }
 
-                    public void Verify() { }
-
                     public void Verify(Expression<Action<T>> _) { }
 
                     public void Verify<TResult>(Expression<Func<T, TResult>> _) { }
@@ -42,6 +40,8 @@ namespace PosInformatique.Moq.Analyzers.Tests
                 public class Mock
                 {
                     public static void Verify(params Mock[] mocks) { }
+
+                    public void Verify() { }
 
                     public void VerifyAll() { }
 

--- a/tests/Moq.Analyzers.Tests/MoqLibrary.cs
+++ b/tests/Moq.Analyzers.Tests/MoqLibrary.cs
@@ -19,6 +19,8 @@ namespace PosInformatique.Moq.Analyzers.Tests
 
                     public Mock(params object[] args) { }
 
+                    public Mock<TInterface> As<TInterface>() { return null; }
+
                     public ISetup Setup(Action<T> act) { return null; }
 
                     public ISetup<TResult> Setup<TResult>(Func<T, TResult> func) { return default; }


### PR DESCRIPTION
- Add new rules:
  - PosInfoMoq2007: The `As<T>()` method can be used only with interfaces (fixes: #19).
  - PosInfoMoq2008: The `Verify()` method must be used only on overridable members.
- Add the support of static methods `VerifyAll()` and `Verify()` for the PosInfoMoq2000 rule (fixes: #20).
- Various optimizations to increase speed of analysis.
- Various optimizations to reduce memory usage.
- Add hyperlink to the documentation of the rules.