### PR TITLE
v1.9.2

### DIFF
--- a/.github/workflows/github-actions-release.yml
+++ b/.github/workflows/github-actions-release.yml
@@ -7,7 +7,7 @@ on:
         type: string
         description: The version of the library
         required: true
-        default: 1.9.1
+        default: 1.9.2
       VersionSuffix:
         type: string
         description: The version suffix of the library (for example rc.1)

--- a/src/Moq.Analyzers/Moq.Analyzers.csproj
+++ b/src/Moq.Analyzers/Moq.Analyzers.csproj
@@ -17,6 +17,10 @@
     <PackageProjectUrl>https://github.com/PosInformatique/PosInformatique.Moq.Analyzers</PackageProjectUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>
+      1.9.2
+      - Fix the PosInfoMoq1003 to raise warnings when using InSequence() method.
+      - Fix the PosInfoMoq2003 to raise errors when using InSequence() method.
+
       1.9.1
       - Add new rules:
         - PosInfoMoq2009: Mock.Of&lt;T&gt; method must be used only to mock non-sealed class

--- a/src/Moq.Analyzers/MoqSymbols.cs
+++ b/src/Moq.Analyzers/MoqSymbols.cs
@@ -44,12 +44,15 @@ namespace PosInformatique.Moq.Analyzers
         private MoqSymbols(INamedTypeSymbol mockGenericClass, Compilation compilation)
         {
             this.mockGenericClass = mockGenericClass;
+
+            var setupConditionResultInterface = new Lazy<INamedTypeSymbol>(() => compilation.GetTypeByMetadataName("Moq.Language.ISetupConditionResult`1")!);
+
             this.mockBehaviorEnum = new Lazy<INamedTypeSymbol>(() => compilation.GetTypeByMetadataName("Moq.MockBehavior")!);
             this.isAnyTypeClass = new Lazy<INamedTypeSymbol>(() => compilation.GetTypeByMetadataName("Moq.It+IsAnyType")!);
             this.isAnyMethod = new Lazy<ISymbol>(() => compilation.GetTypeByMetadataName("Moq.It")!.GetMembers("IsAny").Single());
             this.verifiesInterface = new Lazy<INamedTypeSymbol>(() => compilation.GetTypeByMetadataName("Moq.Language.IVerifies")!);
 
-            this.setupMethods = new Lazy<IReadOnlyList<IMethodSymbol>>(() => mockGenericClass.GetMembers("Setup").OfType<IMethodSymbol>().ToArray());
+            this.setupMethods = new Lazy<IReadOnlyList<IMethodSymbol>>(() => mockGenericClass.GetMembers("Setup").Concat(setupConditionResultInterface.Value.GetMembers("Setup")).OfType<IMethodSymbol>().ToArray());
             this.mockBehaviorStrictField = new Lazy<ISymbol>(() => this.mockBehaviorEnum.Value.GetMembers("Strict").First());
             this.setupProtectedMethods = new Lazy<IReadOnlyList<IMethodSymbol>>(() => compilation.GetTypeByMetadataName("Moq.Protected.IProtectedMock`1")!.GetMembers("Setup").OfType<IMethodSymbol>().ToArray());
             this.asMethod = new Lazy<ISymbol>(() => mockGenericClass.GetMembers("As").Single());

--- a/tests/Moq.Analyzers.Tests/Analyzers/CallBackDelegateMustMatchMockedMethodAnalyzerTest.cs
+++ b/tests/Moq.Analyzers.Tests/Analyzers/CallBackDelegateMustMatchMockedMethodAnalyzerTest.cs
@@ -10,8 +10,10 @@ namespace PosInformatique.Moq.Analyzers.Tests
 
     public class CallBackDelegateMustMatchMockedMethodAnalyzerTest
     {
-        [Fact]
-        public async Task CallBackSignatureMatch_NoDiagnosticReported()
+        [Theory]
+        [InlineData("")]
+        [InlineData(".InSequence(sequence)")]
+        public async Task CallBackSignatureMatch_NoDiagnosticReported(string sequence)
         {
             var source = @"
                 namespace ConsoleApplication1
@@ -23,31 +25,33 @@ namespace PosInformatique.Moq.Analyzers.Tests
                     {
                         public void TestMethod()
                         {
+                            var sequence = new MockSequence();
+
                             var mock1 = new Mock<I>();
 
-                            mock1.Setup(m => m.TestMethod())
+                            mock1" + sequence + @".Setup(m => m.TestMethod())
                                 .Callback(() => { })
                                 .Throws(new Exception());
-                            mock1.Setup(m => m.TestMethod(default))
+                            mock1" + sequence + @".Setup(m => m.TestMethod(default))
                                 .Callback((string x) => { })
                                 .Throws(new Exception());
-                            mock1.Setup(m => m.TestMethod(default, default))
+                            mock1" + sequence + @".Setup(m => m.TestMethod(default, default))
                                 .Callback((string x, int y) => { })
                                 .Throws(new Exception());
-                            mock1.Setup(m => m.TestGenericMethod(1234))
+                            mock1" + sequence + @".Setup(m => m.TestGenericMethod(1234))
                                 .Callback((int x) => { })
                                 .Throws(new Exception());
-                            mock1.Setup(m => m.TestGenericMethod(It.IsAny<It.IsAnyType>()))
+                            mock1" + sequence + @".Setup(m => m.TestGenericMethod(It.IsAny<It.IsAnyType>()))
                                 .Callback((object x) => { })
                                 .Throws(new Exception());
 
-                            mock1.Setup(m => m.TestMethodReturn())
+                            mock1" + sequence + @".Setup(m => m.TestMethodReturn())
                                 .Callback(() => { })
                                 .Returns(1234);
-                            mock1.Setup(m => m.TestMethodReturn(default))
+                            mock1" + sequence + @".Setup(m => m.TestMethodReturn(default))
                                 .Callback((string x) => { })
                                 .Returns(1234);
-                            mock1.Setup(m => m.TestMethodReturn(default, default))
+                            mock1" + sequence + @".Setup(m => m.TestMethodReturn(default, default))
                                 .Callback((string x, int y) => { })
                                 .Returns(1234);
 
@@ -80,8 +84,10 @@ namespace PosInformatique.Moq.Analyzers.Tests
             await Verifier.VerifyAnalyzerAsync(source);
         }
 
-        [Fact]
-        public async Task CallBackSignatureNotMatch_DiagnosticReported()
+        [Theory]
+        [InlineData("")]
+        [InlineData(".InSequence(sequence)")]
+        public async Task CallBackSignatureNotMatch_DiagnosticReported(string sequence)
         {
             var source = @"
                 namespace ConsoleApplication1
@@ -93,37 +99,39 @@ namespace PosInformatique.Moq.Analyzers.Tests
                     {
                         public void TestMethod()
                         {
+                            var sequence = new MockSequence();
+
                             var mock1 = new Mock<I>();
 
-                            mock1.Setup(m => m.TestMethod())
+                            mock1" + sequence + @".Setup(m => m.TestMethod())
                                 .Callback([|(int too, int much, int parameters)|] => { })
                                 .Throws(new Exception());
-                            mock1.Setup(m => m.TestMethod(default))
+                            mock1" + sequence + @".Setup(m => m.TestMethod(default))
                                 .Callback([|()|] => { })
                                 .Throws(new Exception());
-                            mock1.Setup(m => m.TestMethod(default))
+                            mock1" + sequence + @".Setup(m => m.TestMethod(default))
                                 .Callback(([|int otherType|]) => { })
                                 .Throws(new Exception());
-                            mock1.Setup(m => m.TestMethod(default))
+                            mock1" + sequence + @".Setup(m => m.TestMethod(default))
                                 .Callback([|(int too, int much, int parameters)|] => { })
                                 .Throws(new Exception());
-                            mock1.Setup(m => m.TestGenericMethod(1234))
+                            mock1" + sequence + @".Setup(m => m.TestGenericMethod(1234))
                                 .Callback(([|string x|]) => { })
                                 .Throws(new Exception());
-                            mock1.Setup(m => m.TestGenericMethod(It.IsAny<It.IsAnyType>()))
+                            mock1" + sequence + @".Setup(m => m.TestGenericMethod(It.IsAny<It.IsAnyType>()))
                                 .Callback(([|string x|]) => { })
                                 .Throws(new Exception());
 
-                            mock1.Setup(m => m.TestMethodReturn())
+                            mock1" + sequence + @".Setup(m => m.TestMethodReturn())
                                 .Callback([|(int too, int much, int parameters)|] => { })
                                 .Returns(1234);
-                            mock1.Setup(m => m.TestMethodReturn(default))
+                            mock1" + sequence + @".Setup(m => m.TestMethodReturn(default))
                                 .Callback([|()|] => { })
                                 .Returns(1234);
-                            mock1.Setup(m => m.TestMethodReturn(default))
+                            mock1" + sequence + @".Setup(m => m.TestMethodReturn(default))
                                 .Callback(([|int otherType|]) => { })
                                 .Returns(1234);
-                            mock1.Setup(m => m.TestMethodReturn(default))
+                            mock1" + sequence + @".Setup(m => m.TestMethodReturn(default))
                                 .Callback([|(int too, int much, int parameters)|] => { })
                                 .Returns(1234);
                         }

--- a/tests/Moq.Analyzers.Tests/Analyzers/ConstructorArgumentsMustMatchAnalyzerTest.cs
+++ b/tests/Moq.Analyzers.Tests/Analyzers/ConstructorArgumentsMustMatchAnalyzerTest.cs
@@ -208,7 +208,6 @@ namespace PosInformatique.Moq.Analyzers.Tests
             await Verifier.VerifyAnalyzerAsync(source);
         }
 
-
         [Theory]
         [InlineData("class")]
         [InlineData("abstract class")]


### PR DESCRIPTION
### Improvements/Fixes

- Fix the [PosInfoMoq1003](https://posinformatique.github.io/PosInformatique.Moq.Analyzers/docs/Design/PosInfoMoq1003.html) to raise warnings when using InSequence() method.
- Fix the [PosInfoMoq2003](https://posinformatique.github.io/PosInformatique.Moq.Analyzers/docs/Compilation/PosInfoMoq2003.html) to raise errors when using InSequence() method.